### PR TITLE
fix(ci): run e2e in docker without TTY

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,4 +9,6 @@ echo "--------------------------------------------------------------------------
 echo "Running end to end tests"
 echo "----------------------------------------------------------------------------------------------------"
 
-npm run test:e2e
+npm run test:e2e:docker:cleanup
+npm run test:e2e:docker
+npm run test:e2e:docker:cleanup

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,6 +9,10 @@ echo "--------------------------------------------------------------------------
 echo "Running end to end tests"
 echo "----------------------------------------------------------------------------------------------------"
 
-npm run test:e2e:docker:cleanup
+cleanup() {
+	docker compose -f docker/test/compose.yml down
+}
+trap cleanup EXIT
+
+docker compose -f docker/test/compose.yml down
 npm run test:e2e:docker
-npm run test:e2e:docker:cleanup

--- a/docker/dev/compose.yml
+++ b/docker/dev/compose.yml
@@ -64,8 +64,8 @@ services:
     working_dir: /workspace
     # command: sleep infinity  # Keep container running for dev
     ports:
-      - "3001:${HTTP_PORT}"   # NestJS
-      - "9229:9229"   # Debugger
+      - "3004:${HTTP_PORT}"   # NestJS
+      - "9231:9229"   # Debugger
     networks:
       - whispr-network
     depends_on:

--- a/docker/dev/compose.yml
+++ b/docker/dev/compose.yml
@@ -64,8 +64,8 @@ services:
     working_dir: /workspace
     # command: sleep infinity  # Keep container running for dev
     ports:
-      - "3004:${HTTP_PORT}"   # NestJS
-      - "9231:9229"   # Debugger
+      - "${HTTP_PORT_HOST:-3004}:${HTTP_PORT}"   # NestJS
+      - "${DEBUG_PORT_HOST:-9231}:9229"   # Debugger
     networks:
       - whispr-network
     depends_on:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:e2e:docker": "docker compose -f docker/test/compose.yml run --rm --build test-runner",
+    "test:e2e:docker": "docker compose -f docker/test/compose.yml run -T --rm --build test-runner",
     "test:e2e:docker:cleanup": "docker compose -f docker/test/compose.yml down -v",
     "typecheck": "tsc --noEmit",
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/modules/app/migrations/migration.config.ts",


### PR DESCRIPTION
## Summary
- Fix e2e tests to run in Docker without requiring a TTY
- Fix scheduling service ports in dev compose

## Test plan
- [ ] Vérifier que la pipeline CI e2e passe sans erreur TTY
- [ ] Vérifier que les ports du scheduling-service sont corrects en dev