### PR TITLE
fix(swagger): move swagger UI route from /api/docs to /swagger

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -58,13 +58,13 @@ async function bootstrap() {
 			.build();
 
 		const document = SwaggerModule.createDocument(app, config);
-		SwaggerModule.setup('/api/docs', app, document, {
+		SwaggerModule.setup('swagger', app, document, {
 			swaggerOptions: {
 				persistAuthorization: true,
 			},
 		});
 
-		logger.log(`Swagger documentation available at /api/docs`);
+		logger.log(`Swagger documentation available at /swagger`);
 	}
 
 	// Resolve .proto path for both dev (src) and prod (dist)
@@ -111,7 +111,7 @@ async function bootstrap() {
 	logger.log(`📈 Metrics available at http://localhost:${port}/api/v1/monitoring/metrics`);
 
 	if (configService.get('SWAGGER_ENABLED', 'true') === 'true') {
-		logger.log(`📚 API Documentation available at http://localhost:${port}/api/docs`);
+		logger.log(`📚 API Documentation available at http://localhost:${port}/swagger`);
 	}
 
 	// Graceful shutdown logging (enableShutdownHooks handles SIGTERM/SIGINT → app.close())


### PR DESCRIPTION
## Summary
- Change swagger route from `/api/docs` to `/swagger` for consistency with other services
- All services now expose swagger at `/<service>/swagger` via Nginx path-stripping
- URL becomes `https://whispr-api.roadmvn.com/scheduling/swagger`

## Test plan
- [ ] `https://whispr-api.roadmvn.com/scheduling/swagger` accessible after deploy
- [ ] Unit tests pass (71/71)