### PR TITLE
ci: add deploy/preprod to CI trigger branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: 🚀 CI Pipeline
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, deploy/preprod]
 
 permissions:
   contents: read

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ async function bootstrap() {
 			.setDescription('Task scheduling and orchestration service')
 			.setVersion('1.0.0')
 			.addBearerAuth()
+			.addServer('/', 'Current host')
 			.addTag('Scheduler', 'Job scheduling and execution')
 			.addTag('Monitoring', 'Health checks and metrics')
 			.build();


### PR DESCRIPTION
## Summary
- Add deploy/preprod branch to CI pipeline triggers (push + pull_request)
- Enables automatic CI when pushing to preprod branch

## Test plan
- [ ] CI triggers on push to deploy/preprod
- [ ] Existing main/develop triggers unaffected