### PR TITLE
fix(swagger): use current host instead of hardcoded domains

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ async function bootstrap() {
 			.setDescription('Task scheduling and orchestration service')
 			.setVersion('1.0.0')
 			.addBearerAuth()
+			.addServer('/', 'Current host')
 			.addTag('Scheduler', 'Job scheduling and execution')
 			.addTag('Monitoring', 'Health checks and metrics')
 			.build();


### PR DESCRIPTION
## Summary
- Add relative server path `/` so Swagger 'Try it out' targets the current host
- Works on any environment (prod, preprod, local) without hardcoded URLs

## Test plan
- [ ] Swagger UI loads correctly
- [ ] 'Try it out' sends requests to the correct host