### PR TITLE
[WHISPR-1317] fix(scheduling): CRITICAL IDOR + unsafe lock release

### DIFF
--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,27 @@
+import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Request } from 'express';
+
+export interface AuthUser {
+	userId: string;
+	jti: string;
+	deviceId: string;
+	fingerprint?: string;
+}
+
+/**
+ * Recupere l'identite authentifiee posee par le JwtAuthGuard sur la requete.
+ * Utiliser systematiquement plutot que de lire userId depuis la query/body
+ * (sinon: IDOR direct, un user peut manipuler les ressources d'un autre).
+ */
+export const CurrentUser = createParamDecorator(
+	(data: keyof AuthUser | undefined, ctx: ExecutionContext): AuthUser | AuthUser[keyof AuthUser] => {
+		const request = ctx.switchToHttp().getRequest<Request & { user?: AuthUser }>();
+		const user = request.user;
+
+		if (!user || !user.userId) {
+			throw new UnauthorizedException();
+		}
+
+		return data ? user[data] : user;
+	}
+);

--- a/src/modules/scheduled-messages/controllers/scheduled-messages.controller.ts
+++ b/src/modules/scheduled-messages/controllers/scheduled-messages.controller.ts
@@ -6,26 +6,18 @@ import {
 	Delete,
 	Body,
 	Param,
-	Query,
 	HttpCode,
 	HttpStatus,
 	ParseUUIDPipe,
 	UseInterceptors,
 } from '@nestjs/common';
-import {
-	ApiTags,
-	ApiOperation,
-	ApiResponse,
-	ApiParam,
-	ApiQuery,
-	ApiBearerAuth,
-	ApiBody,
-} from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { ScheduledMessagesService } from '../services/scheduled-messages.service';
 import { CreateScheduledMessageDto } from '../dto/create-scheduled-message.dto';
 import { UpdateScheduledMessageDto } from '../dto/update-scheduled-message.dto';
 import { ScheduledMessageResponseDto } from '../dto/scheduled-message-response.dto';
 import { LoggingInterceptor } from '@/common/interceptors/logging.interceptor';
+import { CurrentUser } from '@/common/decorators/current-user.decorator';
 
 @ApiTags('Scheduled Messages')
 @ApiBearerAuth()
@@ -44,36 +36,28 @@ export class ScheduledMessagesController {
 		type: ScheduledMessageResponseDto,
 	})
 	@ApiResponse({ status: 400, description: 'Invalid input data' })
-	async create(@Body() dto: CreateScheduledMessageDto): Promise<ScheduledMessageResponseDto> {
-		return this.scheduledMessagesService.create(dto);
+	async create(
+		@CurrentUser('userId') userId: string,
+		@Body() dto: CreateScheduledMessageDto
+	): Promise<ScheduledMessageResponseDto> {
+		// userId provient du JWT, jamais du body : sinon IDOR.
+		return this.scheduledMessagesService.create(userId, dto);
 	}
 
 	@Get()
 	@ApiOperation({ summary: "List user's scheduled messages" })
-	@ApiQuery({
-		name: 'userId',
-		required: true,
-		type: 'string',
-		description: 'User ID to filter scheduled messages',
-	})
 	@ApiResponse({
 		status: 200,
 		description: 'Scheduled messages retrieved successfully',
 		type: [ScheduledMessageResponseDto],
 	})
-	async findAll(@Query('userId', ParseUUIDPipe) userId: string): Promise<ScheduledMessageResponseDto[]> {
+	async findAll(@CurrentUser('userId') userId: string): Promise<ScheduledMessageResponseDto[]> {
 		return this.scheduledMessagesService.findAllByUser(userId);
 	}
 
 	@Get(':id')
 	@ApiOperation({ summary: 'Get a scheduled message by ID' })
 	@ApiParam({ name: 'id', description: 'Scheduled message ID', type: 'string' })
-	@ApiQuery({
-		name: 'userId',
-		required: true,
-		type: 'string',
-		description: 'User ID for ownership validation',
-	})
 	@ApiResponse({
 		status: 200,
 		description: 'Scheduled message retrieved successfully',
@@ -82,7 +66,7 @@ export class ScheduledMessagesController {
 	@ApiResponse({ status: 404, description: 'Scheduled message not found' })
 	async findOne(
 		@Param('id', ParseUUIDPipe) id: string,
-		@Query('userId', ParseUUIDPipe) userId: string
+		@CurrentUser('userId') userId: string
 	): Promise<ScheduledMessageResponseDto> {
 		return this.scheduledMessagesService.findOne(id, userId);
 	}
@@ -90,12 +74,6 @@ export class ScheduledMessagesController {
 	@Patch(':id')
 	@ApiOperation({ summary: 'Update a scheduled message (only if still pending)' })
 	@ApiParam({ name: 'id', description: 'Scheduled message ID', type: 'string' })
-	@ApiQuery({
-		name: 'userId',
-		required: true,
-		type: 'string',
-		description: 'User ID for ownership validation',
-	})
 	@ApiBody({ type: UpdateScheduledMessageDto })
 	@ApiResponse({
 		status: 200,
@@ -106,7 +84,7 @@ export class ScheduledMessagesController {
 	@ApiResponse({ status: 404, description: 'Scheduled message not found' })
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
-		@Query('userId', ParseUUIDPipe) userId: string,
+		@CurrentUser('userId') userId: string,
 		@Body() dto: UpdateScheduledMessageDto
 	): Promise<ScheduledMessageResponseDto> {
 		return this.scheduledMessagesService.update(id, userId, dto);
@@ -116,18 +94,12 @@ export class ScheduledMessagesController {
 	@HttpCode(HttpStatus.NO_CONTENT)
 	@ApiOperation({ summary: 'Cancel a scheduled message' })
 	@ApiParam({ name: 'id', description: 'Scheduled message ID', type: 'string' })
-	@ApiQuery({
-		name: 'userId',
-		required: true,
-		type: 'string',
-		description: 'User ID for ownership validation',
-	})
 	@ApiResponse({ status: 204, description: 'Scheduled message cancelled successfully' })
 	@ApiResponse({ status: 400, description: 'Cannot cancel non-pending message' })
 	@ApiResponse({ status: 404, description: 'Scheduled message not found' })
 	async cancel(
 		@Param('id', ParseUUIDPipe) id: string,
-		@Query('userId', ParseUUIDPipe) userId: string
+		@CurrentUser('userId') userId: string
 	): Promise<void> {
 		return this.scheduledMessagesService.cancel(id, userId);
 	}

--- a/src/modules/scheduled-messages/dto/create-scheduled-message.dto.ts
+++ b/src/modules/scheduled-messages/dto/create-scheduled-message.dto.ts
@@ -3,14 +3,6 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateScheduledMessageDto {
 	@ApiProperty({
-		description: 'ID of the user scheduling the message',
-		example: 'a1b2c3d4-5678-9abc-def0-123456789abc',
-	})
-	@IsUUID()
-	@IsNotEmpty()
-	userId: string;
-
-	@ApiProperty({
 		description: 'ID of the conversation to send the message to',
 		example: 'b2c3d4e5-6789-abcd-ef01-23456789abcd',
 	})

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
@@ -1,0 +1,205 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { ScheduledMessagesService } from './scheduled-messages.service';
+import { ScheduledMessage, ScheduledMessageStatus } from '../entities/scheduled-message.entity';
+import { MessagingGrpcClient } from '@/modules/grpc/clients/messaging.client';
+
+// Mock minimal du driver ioredis pour eviter d'ouvrir une connexion reelle.
+type RedisMock = {
+	set: jest.Mock;
+	del: jest.Mock;
+	runScript: jest.Mock;
+	quit: jest.Mock;
+};
+
+const redisMock: RedisMock = {
+	set: jest.fn(),
+	del: jest.fn(),
+	runScript: jest.fn(),
+	quit: jest.fn(),
+};
+
+jest.mock('ioredis', () => {
+	const ctor = jest.fn().mockImplementation(() => ({
+		set: redisMock.set,
+		del: redisMock.del,
+		// On expose la cle "eval" attendue par ioredis vers notre mock.
+		eval: redisMock.runScript,
+		quit: redisMock.quit,
+	}));
+	return { __esModule: true, default: ctor };
+});
+
+describe('ScheduledMessagesService', () => {
+	let service: ScheduledMessagesService;
+	let repository: { create: jest.Mock; save: jest.Mock; find: jest.Mock; findOne: jest.Mock };
+	let messagingClient: { sendScheduledMessage: jest.Mock };
+
+	beforeEach(async () => {
+		jest.clearAllMocks();
+
+		repository = {
+			create: jest.fn((entity) => entity),
+			save: jest.fn((entity) => Promise.resolve({ ...entity, id: 'persisted-id' })),
+			find: jest.fn().mockResolvedValue([]),
+			findOne: jest.fn(),
+		};
+
+		messagingClient = {
+			sendScheduledMessage: jest.fn(),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				ScheduledMessagesService,
+				{
+					provide: getRepositoryToken(ScheduledMessage),
+					useValue: repository,
+				},
+				{
+					provide: MessagingGrpcClient,
+					useValue: messagingClient,
+				},
+				{
+					provide: ConfigService,
+					useValue: { get: jest.fn() },
+				},
+			],
+		}).compile();
+
+		service = module.get<ScheduledMessagesService>(ScheduledMessagesService);
+	});
+
+	describe('create', () => {
+		it('persiste le userId provenant de la JWT, jamais celui du DTO', async () => {
+			const futureDate = new Date(Date.now() + 60_000).toISOString();
+			const jwtUserId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+			const dto = {
+				conversationId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+				content: 'hello',
+				scheduledAt: futureDate,
+			};
+
+			await service.create(jwtUserId, dto);
+
+			expect(repository.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					userId: jwtUserId,
+					conversationId: dto.conversationId,
+					status: ScheduledMessageStatus.PENDING,
+				})
+			);
+		});
+
+		it('refuse une date passee', async () => {
+			await expect(
+				service.create('uid', {
+					conversationId: 'cid',
+					content: 'x',
+					scheduledAt: new Date(Date.now() - 1000).toISOString(),
+				})
+			).rejects.toThrow('scheduled_at must be in the future');
+		});
+	});
+
+	describe('findOne / update / cancel — scoping par userId', () => {
+		it('findOne scope la query au userId fourni', async () => {
+			repository.findOne.mockResolvedValue(null);
+			await expect(service.findOne('msg-id', 'user-A')).rejects.toThrow('not found');
+			expect(repository.findOne).toHaveBeenCalledWith({
+				where: { id: 'msg-id', userId: 'user-A' },
+			});
+		});
+
+		it('update scope la query au userId fourni', async () => {
+			repository.findOne.mockResolvedValue(null);
+			await expect(service.update('msg-id', 'user-A', { content: 'x' })).rejects.toThrow('not found');
+			expect(repository.findOne).toHaveBeenCalledWith({
+				where: { id: 'msg-id', userId: 'user-A' },
+			});
+		});
+
+		it('cancel scope la query au userId fourni', async () => {
+			repository.findOne.mockResolvedValue(null);
+			await expect(service.cancel('msg-id', 'user-A')).rejects.toThrow('not found');
+			expect(repository.findOne).toHaveBeenCalledWith({
+				where: { id: 'msg-id', userId: 'user-A' },
+			});
+		});
+	});
+
+	describe('processDueMessages — Redis lock', () => {
+		it('utilise un owner ID unique pour SET NX et un script Lua au release', async () => {
+			redisMock.set.mockResolvedValue('OK');
+			redisMock.runScript.mockResolvedValue(1);
+			repository.find.mockResolvedValue([]);
+
+			await service.processDueMessages();
+
+			expect(redisMock.set).toHaveBeenCalledTimes(1);
+			const [, ownerIdAtAcquire] = redisMock.set.mock.calls[0];
+			expect(typeof ownerIdAtAcquire).toBe('string');
+			expect(ownerIdAtAcquire).toMatch(/^\d+:/);
+
+			expect(redisMock.runScript).toHaveBeenCalledTimes(1);
+			const scriptArgs = redisMock.runScript.mock.calls[0];
+			// Signature ioredis : (script, numKeys, key, argv...)
+			expect(scriptArgs[0]).toContain("redis.call('get', KEYS[1])");
+			expect(scriptArgs[0]).toContain("redis.call('del', KEYS[1])");
+			expect(scriptArgs[1]).toBe(1);
+			expect(scriptArgs[2]).toBe('scheduled-messages:lock:process');
+			expect(scriptArgs[3]).toBe(ownerIdAtAcquire);
+
+			// Plus jamais de DEL bare : c'etait la vulnerabilite.
+			expect(redisMock.del).not.toHaveBeenCalled();
+		});
+
+		it("n'execute pas le batch si le lock est deja pris", async () => {
+			redisMock.set.mockResolvedValue(null);
+
+			await service.processDueMessages();
+
+			expect(repository.find).not.toHaveBeenCalled();
+			// Pas de release puisqu'on a pas pris le lock.
+			expect(redisMock.runScript).not.toHaveBeenCalled();
+		});
+
+		it('release atomique meme si le batch jette une exception', async () => {
+			redisMock.set.mockResolvedValue('OK');
+			redisMock.runScript.mockResolvedValue(1);
+			repository.find.mockRejectedValue(new Error('db down'));
+
+			await service.processDueMessages();
+
+			expect(redisMock.runScript).toHaveBeenCalledTimes(1);
+		});
+
+		it('deux instances ont des owner IDs distincts (cas multi-pod)', async () => {
+			redisMock.set.mockResolvedValue('OK');
+			redisMock.runScript.mockResolvedValue(1);
+			repository.find.mockResolvedValue([]);
+
+			await service.processDueMessages();
+			const ownerA = redisMock.set.mock.calls[0][1];
+
+			// On instancie un second service pour simuler un autre pod.
+			const moduleB: TestingModule = await Test.createTestingModule({
+				providers: [
+					ScheduledMessagesService,
+					{ provide: getRepositoryToken(ScheduledMessage), useValue: repository },
+					{ provide: MessagingGrpcClient, useValue: messagingClient },
+					{ provide: ConfigService, useValue: { get: jest.fn() } },
+				],
+			}).compile();
+			const serviceB = moduleB.get<ScheduledMessagesService>(ScheduledMessagesService);
+
+			redisMock.set.mockClear();
+			redisMock.set.mockResolvedValue('OK');
+			await serviceB.processDueMessages();
+			const ownerB = redisMock.set.mock.calls[0][1];
+
+			expect(ownerA).not.toBe(ownerB);
+		});
+	});
+});

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.ts
@@ -9,15 +9,27 @@ import { UpdateScheduledMessageDto } from '../dto/update-scheduled-message.dto';
 import { ScheduledMessageResponseDto } from '../dto/scheduled-message-response.dto';
 import { MessagingGrpcClient } from '@/modules/grpc/clients/messaging.client';
 import Redis from 'ioredis';
+import { randomUUID } from 'crypto';
 import { buildRedisOptions } from '@/config/redis.config';
 
 const LOCK_KEY_PREFIX = 'scheduled-messages:lock:';
 const LOCK_TTL_SECONDS = 55;
 
+// Lua atomique : ne supprime la cle que si la valeur appartient a ce process.
+// Evite qu'un pod expire son lock et delete celui d'un autre pod.
+const RELEASE_LOCK_LUA = `if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('del', KEYS[1])
+else
+  return 0
+end`;
+
 @Injectable()
 export class ScheduledMessagesService {
 	private readonly logger = new Logger(ScheduledMessagesService.name);
 	private readonly redis: Redis;
+	// Identifiant unique du process : sert de owner pour le lock distribue.
+	// Genere une seule fois par instance, persiste tant que le pod est up.
+	private readonly lockOwnerId = `${process.pid}:${randomUUID()}`;
 
 	constructor(
 		@InjectRepository(ScheduledMessage)
@@ -213,14 +225,27 @@ export class ScheduledMessagesService {
 	/**
 	 * Acquires a distributed lock using Redis SET NX EX.
 	 * Returns true if the lock was acquired, false otherwise.
+	 * Stocke un owner ID unique pour permettre une release sure.
 	 */
 	private async acquireLock(key: string, ttlSeconds: number): Promise<boolean> {
-		const result = await this.redis.set(key, process.pid.toString(), 'EX', ttlSeconds, 'NX');
+		const result = await this.redis.set(key, this.lockOwnerId, 'EX', ttlSeconds, 'NX');
 		return result === 'OK';
 	}
 
+	/**
+	 * Release atomique via script Lua cote Redis : delete uniquement si la
+	 * valeur correspond a notre owner ID. Sinon, le lock appartient a un autre
+	 * pod (le notre a expire) et on ne touche a rien.
+	 */
 	private async releaseLock(key: string): Promise<void> {
-		await this.redis.del(key);
+		try {
+			await this.redis.eval(RELEASE_LOCK_LUA, 1, key, this.lockOwnerId);
+		} catch (error) {
+			this.logger.warn('Failed to release scheduled-messages lock', {
+				key,
+				error: (error as Error).message,
+			});
+		}
 	}
 
 	private toResponse(message: ScheduledMessage): ScheduledMessageResponseDto {

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.ts
@@ -28,7 +28,7 @@ export class ScheduledMessagesService {
 		this.redis = new Redis(buildRedisOptions(this.configService));
 	}
 
-	async create(dto: CreateScheduledMessageDto): Promise<ScheduledMessageResponseDto> {
+	async create(userId: string, dto: CreateScheduledMessageDto): Promise<ScheduledMessageResponseDto> {
 		const scheduledAt = new Date(dto.scheduledAt);
 
 		if (scheduledAt <= new Date()) {
@@ -36,7 +36,7 @@ export class ScheduledMessagesService {
 		}
 
 		const message = this.scheduledMessageRepository.create({
-			userId: dto.userId,
+			userId,
 			conversationId: dto.conversationId,
 			content: dto.content,
 			metadata: dto.metadata || null,

--- a/test/scheduled-messages-idor.e2e-spec.ts
+++ b/test/scheduled-messages-idor.e2e-spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { ScheduledMessagesController } from '../src/modules/scheduled-messages/controllers/scheduled-messages.controller';
+import { ScheduledMessagesService } from '../src/modules/scheduled-messages/services/scheduled-messages.service';
+
+/**
+ * Verifie que les endpoints scheduled-messages ne peuvent pas etre detournes
+ * via un userId injecte dans la query ou le body : c'est strictement la JWT
+ * (posee dans req.user par le JwtAuthGuard) qui scope les operations.
+ */
+describe('ScheduledMessages IDOR (e2e)', () => {
+	let app: INestApplication;
+	let serviceMock: {
+		create: jest.Mock;
+		findAllByUser: jest.Mock;
+		findOne: jest.Mock;
+		update: jest.Mock;
+		cancel: jest.Mock;
+	};
+	const VICTIM_ID = '11111111-1111-4111-8111-111111111111';
+	const ATTACKER_ID = '22222222-2222-4222-8222-222222222222';
+	const MESSAGE_ID = '33333333-3333-4333-8333-333333333333';
+	const CONVERSATION_ID = '44444444-4444-4444-8444-444444444444';
+
+	beforeAll(async () => {
+		serviceMock = {
+			create: jest.fn().mockImplementation((userId: string, dto: any) =>
+				Promise.resolve({
+					id: MESSAGE_ID,
+					userId,
+					conversationId: dto.conversationId,
+					content: dto.content,
+					metadata: dto.metadata ?? null,
+					scheduledAt: new Date(dto.scheduledAt),
+					status: 'pending',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				})
+			),
+			findAllByUser: jest
+				.fn()
+				.mockImplementation((userId: string) =>
+					Promise.resolve([{ id: MESSAGE_ID, userId, conversationId: 'c', content: 'x' }])
+				),
+			findOne: jest
+				.fn()
+				.mockImplementation((id: string, userId: string) => Promise.resolve({ id, userId })),
+			update: jest
+				.fn()
+				.mockImplementation((id: string, userId: string) => Promise.resolve({ id, userId })),
+			cancel: jest.fn().mockResolvedValue(undefined),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [ScheduledMessagesController],
+			providers: [{ provide: ScheduledMessagesService, useValue: serviceMock }],
+		}).compile();
+
+		app = module.createNestApplication();
+		app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: false }));
+
+		// Middleware express qui simule le JwtAuthGuard : pose req.user comme
+		// le vrai guard l'aurait fait apres validation de la JWT.
+		app.use((req: any, _res: any, next: () => void) => {
+			req.user = { userId: ATTACKER_ID, jti: 'jti', deviceId: 'dev' };
+			next();
+		});
+
+		await app.init();
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		serviceMock.create.mockImplementation((userId: string, dto: any) =>
+			Promise.resolve({
+				id: MESSAGE_ID,
+				userId,
+				conversationId: dto.conversationId,
+				content: dto.content,
+				metadata: dto.metadata ?? null,
+				scheduledAt: new Date(dto.scheduledAt),
+				status: 'pending',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			})
+		);
+		serviceMock.findAllByUser.mockImplementation((userId: string) =>
+			Promise.resolve([{ id: MESSAGE_ID, userId, conversationId: 'c', content: 'x' }])
+		);
+		serviceMock.findOne.mockImplementation((id: string, userId: string) =>
+			Promise.resolve({ id, userId })
+		);
+		serviceMock.update.mockImplementation((id: string, userId: string) =>
+			Promise.resolve({ id, userId })
+		);
+	});
+
+	it('POST ignore body.userId et utilise le userId de la JWT', async () => {
+		const futureDate = new Date(Date.now() + 60_000).toISOString();
+		const res = await request(app.getHttpServer()).post('/api/v1/scheduled-messages').send({
+			userId: VICTIM_ID, // tentative d'IDOR : champ inconnu, doit etre strippe
+			conversationId: CONVERSATION_ID,
+			content: 'hello',
+			scheduledAt: futureDate,
+		});
+
+		expect(res.status).toBe(201);
+		expect(serviceMock.create).toHaveBeenCalledTimes(1);
+		expect(serviceMock.create.mock.calls[0][0]).toBe(ATTACKER_ID);
+		expect(serviceMock.create.mock.calls[0][1]).not.toHaveProperty('userId');
+		expect(res.body.userId).toBe(ATTACKER_ID);
+	});
+
+	it('GET /scheduled-messages ignore ?userId=victim et scope sur la JWT', async () => {
+		await request(app.getHttpServer()).get(`/api/v1/scheduled-messages?userId=${VICTIM_ID}`).expect(200);
+
+		expect(serviceMock.findAllByUser).toHaveBeenCalledWith(ATTACKER_ID);
+	});
+
+	it('GET /scheduled-messages/:id ignore ?userId=victim', async () => {
+		await request(app.getHttpServer())
+			.get(`/api/v1/scheduled-messages/${MESSAGE_ID}?userId=${VICTIM_ID}`)
+			.expect(200);
+
+		expect(serviceMock.findOne).toHaveBeenCalledWith(MESSAGE_ID, ATTACKER_ID);
+	});
+
+	it('PATCH /scheduled-messages/:id ignore ?userId=victim', async () => {
+		await request(app.getHttpServer())
+			.patch(`/api/v1/scheduled-messages/${MESSAGE_ID}?userId=${VICTIM_ID}`)
+			.send({ content: 'pwned' })
+			.expect(200);
+
+		expect(serviceMock.update).toHaveBeenCalledWith(
+			MESSAGE_ID,
+			ATTACKER_ID,
+			expect.objectContaining({ content: 'pwned' })
+		);
+	});
+
+	it('DELETE /scheduled-messages/:id ignore ?userId=victim', async () => {
+		await request(app.getHttpServer())
+			.delete(`/api/v1/scheduled-messages/${MESSAGE_ID}?userId=${VICTIM_ID}`)
+			.expect(204);
+
+		expect(serviceMock.cancel).toHaveBeenCalledWith(MESSAGE_ID, ATTACKER_ID);
+	});
+});


### PR DESCRIPTION
## Summary

Two security fixes on the scheduled-messages module.

### Finding 1 — CRITICAL — IDOR via query/body userId

The endpoints `GET/POST/PATCH/DELETE /api/v1/scheduled-messages` were taking `userId` from the request (`@Query('userId')` for GET/PATCH/DELETE, `dto.userId` for POST). An authenticated user could pass any other user's UUID and read, modify or cancel their scheduled messages.

Fix:
- New `@CurrentUser` param decorator (`src/common/decorators/current-user.decorator.ts`) that reads `req.user.userId` posed by `JwtAuthGuard`.
- Controller now uses `@CurrentUser('userId')` everywhere; the query/body inputs are gone.
- `CreateScheduledMessageDto` no longer exposes `userId` in the OpenAPI schema; the field is silently stripped by the global `whitelist: true` validation pipe even if a malicious client sends it.
- `ScheduledMessagesService.create` signature now takes `userId` as a separate first arg.

### Finding 2 — HIGH — Unsafe Redis lock release (DEL bare)

`processDueMessages` cron used `redis.del(key)` to release the distributed lock without checking ownership. Pod A could end up deleting the lock that Pod B had just acquired (after Pod A's TTL had expired), leading to duplicate batch processing.

Fix:
- Each instance generates a unique owner ID at startup: `${process.pid}:${randomUUID()}`.
- `acquireLock` stores that owner ID via `SET NX EX`.
- `releaseLock` runs an atomic Lua script that only deletes the key if its value equals our owner ID, otherwise it's a no-op.

## Test plan

- [x] Unit tests green: 90 passed (8 suites). New `scheduled-messages.service.spec.ts` covers the JWT-only userId persistence, per-user scoping in findOne/update/cancel, and the new lock semantics (owner ID, Lua release, multi-pod isolation).
- [x] E2E tests green: 11 passed, 2 pre-existing skipped. New `test/scheduled-messages-idor.e2e-spec.ts` proves that all five endpoints ignore an injected `userId` (query/body) and use the JWT identity.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint "src/**/*.ts"` clean (no new warnings).
- [x] `prettier --write` applied.

Closes WHISPR-1317