### PR TITLE
perf(queues): parallelize retryFailedJobs with Promise.all

### DIFF
--- a/src/modules/queues/services/queue.service.ts
+++ b/src/modules/queues/services/queue.service.ts
@@ -216,18 +216,22 @@ export class QueueService {
 		const queue = this.getQueue(queueName);
 		const failedJobs = await queue.getFailed();
 
-		let retriedCount = 0;
-		for (const job of failedJobs) {
-			try {
-				await job.retry();
-				retriedCount++;
-			} catch (error) {
-				this.logger.warn('Failed to retry job', {
-					jobId: job.id,
-					error: error.message,
-				});
-			}
-		}
+		const results = await Promise.all(
+			failedJobs.map(async (job) => {
+				try {
+					await job.retry();
+					return true;
+				} catch (error) {
+					this.logger.warn('Failed to retry job', {
+						jobId: job.id,
+						error: error.message,
+					});
+					return false;
+				}
+			})
+		);
+
+		const retriedCount = results.filter(Boolean).length;
 
 		this.logger.log('Failed jobs retried', {
 			queueName,


### PR DESCRIPTION
## Summary
- Replaces sequential for-await loop in retryFailedJobs with Promise.all
- All job.retry() calls now fly concurrently instead of waiting for each previous one
- Keeps individual error handling per job - a single failed retry does not abort the rest
- Result counting now uses filter(Boolean) on the resolved results array

## Test plan
- [x] 90 unit tests green
- [x] ESLint clean