### PR TITLE
[WHISPR-1348] feat(security): add helmet middleware for HTTP security headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "cache-manager": "^7.2.4",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "helmet": "^8.1.0",
         "ioredis": "^5.4.1",
         "nodemailer": "^7.0.11",
         "pg": "^8.16.0",
@@ -9782,6 +9783,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hookified": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "cache-manager": "^7.2.4",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "helmet": "^8.1.0",
     "ioredis": "^5.4.1",
     "nodemailer": "^7.0.11",
     "pg": "^8.16.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import helmet from 'helmet';
 import { AppModule } from './modules/app/app.module';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
@@ -19,6 +20,26 @@ async function bootstrap() {
 	});
 
 	const configService = app.get(ConfigService);
+
+	// WHISPR-1348 : entêtes de sécurité HTTP (CSP, HSTS, X-Frame-Options, etc.)
+	// alignés sur auth-service / user-service / media-service. CSP désactivée
+	// quand Swagger est servi en non-prod pour ne pas bloquer le SwaggerUI inline.
+	const swaggerEnabled = configService.get('SWAGGER_ENABLED', 'true') === 'true';
+	app.use(
+		helmet({
+			contentSecurityPolicy: swaggerEnabled
+				? {
+						directives: {
+							defaultSrc: ["'self'"],
+							scriptSrc: ["'self'", "'unsafe-inline'"],
+							styleSrc: ["'self'", "'unsafe-inline'", 'https:'],
+							imgSrc: ["'self'", 'data:'],
+						},
+					}
+				: undefined,
+			crossOriginEmbedderPolicy: swaggerEnabled ? false : undefined,
+		})
+	);
 
 	// Enable CORS if configured
 	if (configService.get('CORS_ENABLED', 'true') === 'true') {
@@ -61,7 +82,7 @@ async function bootstrap() {
 	app.useGlobalInterceptors(new LoggingInterceptor());
 
 	// Swagger configuration
-	if (configService.get('SWAGGER_ENABLED', 'true') === 'true') {
+	if (swaggerEnabled) {
 		const config = new DocumentBuilder()
 			.setTitle('Whispr Scheduling Service API')
 			.setDescription('Task scheduling and orchestration service')
@@ -125,7 +146,7 @@ async function bootstrap() {
 	logger.log(`📊 Health check available at http://localhost:${port}/health`);
 	logger.log(`📈 Metrics available at http://localhost:${port}/api/v1/monitoring/metrics`);
 
-	if (configService.get('SWAGGER_ENABLED', 'true') === 'true') {
+	if (swaggerEnabled) {
 		logger.log(`📚 API Documentation available at http://localhost:${port}/swagger`);
 	}
 

--- a/test/security-headers.e2e-spec.ts
+++ b/test/security-headers.e2e-spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import helmet from 'helmet';
+import { AppModule } from '../src/modules/app/app.module';
+import { JwtAuthGuard } from '../src/modules/auth/jwt-auth.guard';
+
+// WHISPR-1348 : verifie que helmet pose bien les entetes de securite HTTP
+// (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy)
+// alignes sur auth-service / user-service / media-service.
+describe('Security headers (e2e)', () => {
+	let app: INestApplication;
+
+	beforeAll(async () => {
+		const moduleFixture: TestingModule = await Test.createTestingModule({
+			imports: [AppModule],
+		})
+			.overrideProvider(JwtAuthGuard)
+			.useValue({ canActivate: () => true })
+			.compile();
+
+		app = moduleFixture.createNestApplication();
+
+		// Aligne le test sur le bootstrap prod (src/main.ts) : helmet doit etre
+		// actif pour valider que les entetes de securite sont bien poses.
+		app.use(
+			helmet({
+				contentSecurityPolicy: {
+					directives: {
+						defaultSrc: ["'self'"],
+						scriptSrc: ["'self'", "'unsafe-inline'"],
+						styleSrc: ["'self'", "'unsafe-inline'", 'https:'],
+						imgSrc: ["'self'", 'data:'],
+					},
+				},
+				crossOriginEmbedderPolicy: false,
+			})
+		);
+
+		await app.init();
+	});
+
+	afterAll(async () => {
+		if (app) {
+			await app.close();
+		}
+	});
+
+	it('should set X-Content-Type-Options to nosniff', async () => {
+		const response = await request(app.getHttpServer()).get('/health/live').expect(200);
+
+		expect(response.headers['x-content-type-options']).toBe('nosniff');
+	});
+
+	it('should set X-Frame-Options to deny clickjacking', async () => {
+		const response = await request(app.getHttpServer()).get('/health/live').expect(200);
+
+		expect(response.headers['x-frame-options']).toBe('SAMEORIGIN');
+	});
+
+	it('should set a Referrer-Policy header', async () => {
+		const response = await request(app.getHttpServer()).get('/health/live').expect(200);
+
+		expect(response.headers['referrer-policy']).toBeDefined();
+	});
+
+	it('should set a Content-Security-Policy header', async () => {
+		const response = await request(app.getHttpServer()).get('/health/live').expect(200);
+
+		expect(response.headers['content-security-policy']).toBeDefined();
+		expect(response.headers['content-security-policy']).toContain("default-src 'self'");
+	});
+
+	it('should remove the X-Powered-By header to hide framework fingerprint', async () => {
+		const response = await request(app.getHttpServer()).get('/health/live').expect(200);
+
+		expect(response.headers['x-powered-by']).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- Ajoute `helmet()` middleware dans `src/main.ts` pour poser les entetes de securite HTTP (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) et masquer `X-Powered-By`.
- Configuration alignee sur auth-service (WHISPR-1347 / PR #181) et user-service (WHISPR-817) : CSP desactivee quand Swagger est servi en non-prod pour ne pas bloquer le SwaggerUI inline.
- Ajoute test e2e `test/security-headers.e2e-spec.ts` qui couvre les 5 entetes attendus sur `/health/live`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint "src/**/*.ts" --fix` clean
- [x] `npx jest --no-coverage` : 90/90 unit tests verts
- [x] Pre-push hook (docker e2e) vert

Closes WHISPR-1348