### PR TITLE
[WHISPR-1350] fix(scheduling): empecher double-send sur lock expire

### DIFF
--- a/src/modules/app/migrations/1746790000000-AddProcessingStatusScheduledMessages.ts
+++ b/src/modules/app/migrations/1746790000000-AddProcessingStatusScheduledMessages.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Ajoute la valeur 'processing' a l'enum scheduled_messages_status_enum.
+ * Etat intermediaire utilise par processDueMessages pour claim atomiquement
+ * les messages avant envoi (evite le double-send sur lock Redis expire).
+ */
+export class AddProcessingStatusScheduledMessages1746790000000 implements MigrationInterface {
+	name = 'AddProcessingStatusScheduledMessages1746790000000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TYPE "public"."scheduled_messages_status_enum" ADD VALUE IF NOT EXISTS 'processing'`
+		);
+	}
+
+	public async down(): Promise<void> {
+		// PostgreSQL ne supporte pas DROP VALUE sur un enum.
+		// Si rollback necessaire : recreer l'enum sans 'processing' + cast colonne.
+		// On laisse intentionnellement vide : la valeur ajoutee n'est pas bloquante.
+	}
+}

--- a/src/modules/scheduled-messages/entities/scheduled-message.entity.ts
+++ b/src/modules/scheduled-messages/entities/scheduled-message.entity.ts
@@ -2,6 +2,10 @@ import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateCol
 
 export enum ScheduledMessageStatus {
 	PENDING = 'pending',
+	// Etat intermediaire pose atomiquement avant d'envoyer le message.
+	// Empeche un autre pod de retraiter le meme enregistrement si notre lock
+	// Redis expire en cours de boucle (cf processDueMessages).
+	PROCESSING = 'processing',
 	SENT = 'sent',
 	CANCELLED = 'cancelled',
 	FAILED = 'failed',

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
@@ -33,17 +33,41 @@ jest.mock('ioredis', () => {
 
 describe('ScheduledMessagesService', () => {
 	let service: ScheduledMessagesService;
-	let repository: { create: jest.Mock; save: jest.Mock; find: jest.Mock; findOne: jest.Mock };
+	let repository: {
+		create: jest.Mock;
+		save: jest.Mock;
+		find: jest.Mock;
+		findOne: jest.Mock;
+		createQueryBuilder: jest.Mock;
+	};
 	let messagingClient: { sendScheduledMessage: jest.Mock };
+	// QueryBuilder fluent partage par tous les tests : permet de configurer le
+	// retour du UPDATE ... RETURNING * utilise par claimDueMessages.
+	let queryBuilder: {
+		update: jest.Mock;
+		set: jest.Mock;
+		where: jest.Mock;
+		returning: jest.Mock;
+		execute: jest.Mock;
+	};
 
 	beforeEach(async () => {
 		jest.clearAllMocks();
+
+		queryBuilder = {
+			update: jest.fn().mockReturnThis(),
+			set: jest.fn().mockReturnThis(),
+			where: jest.fn().mockReturnThis(),
+			returning: jest.fn().mockReturnThis(),
+			execute: jest.fn().mockResolvedValue({ raw: [] }),
+		};
 
 		repository = {
 			create: jest.fn((entity) => entity),
 			save: jest.fn((entity) => Promise.resolve({ ...entity, id: 'persisted-id' })),
 			find: jest.fn().mockResolvedValue([]),
 			findOne: jest.fn(),
+			createQueryBuilder: jest.fn(() => queryBuilder),
 		};
 
 		messagingClient = {
@@ -173,6 +197,78 @@ describe('ScheduledMessagesService', () => {
 			await service.processDueMessages();
 
 			expect(redisMock.runScript).toHaveBeenCalledTimes(1);
+		});
+
+		it('claim atomique : marque les messages PROCESSING avant envoi', async () => {
+			redisMock.set.mockResolvedValue('OK');
+			redisMock.runScript.mockResolvedValue(1);
+
+			const dueMessage = {
+				id: 'msg-1',
+				userId: 'u',
+				conversationId: 'c',
+				content: 'hello',
+				metadata: null,
+				scheduledAt: new Date(Date.now() - 1000),
+				status: ScheduledMessageStatus.PENDING,
+			};
+
+			repository.find.mockResolvedValue([{ id: dueMessage.id }]);
+			queryBuilder.execute.mockResolvedValue({ raw: [dueMessage] });
+			messagingClient.sendScheduledMessage.mockResolvedValue({ ok: true });
+
+			await service.processDueMessages();
+
+			// Le SELECT initial doit ne demander que les IDs.
+			expect(repository.find).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: expect.objectContaining({ status: ScheduledMessageStatus.PENDING }),
+					select: ['id'],
+				})
+			);
+
+			// L'UPDATE doit poser le filtre status=PENDING (claim atomique).
+			expect(queryBuilder.set).toHaveBeenCalledWith({ status: ScheduledMessageStatus.PROCESSING });
+			expect(queryBuilder.where).toHaveBeenCalledWith(
+				expect.objectContaining({ status: ScheduledMessageStatus.PENDING })
+			);
+
+			// Le message claim a bien ete envoye.
+			expect(messagingClient.sendScheduledMessage).toHaveBeenCalledTimes(1);
+		});
+
+		it('lock expire : un 2e processDueMessages ne retraite pas les messages deja PROCESSING', async () => {
+			redisMock.set.mockResolvedValue('OK');
+			redisMock.runScript.mockResolvedValue(1);
+
+			// Pod A claim le message au 1er tick.
+			const claimedMessage = {
+				id: 'msg-already-claimed',
+				userId: 'u',
+				conversationId: 'c',
+				content: 'hello',
+				metadata: null,
+				scheduledAt: new Date(Date.now() - 1000),
+				status: ScheduledMessageStatus.PENDING,
+			};
+			repository.find.mockResolvedValueOnce([{ id: claimedMessage.id }]);
+			queryBuilder.execute.mockResolvedValueOnce({ raw: [claimedMessage] });
+			messagingClient.sendScheduledMessage.mockResolvedValue({ ok: true });
+
+			await service.processDueMessages();
+			expect(messagingClient.sendScheduledMessage).toHaveBeenCalledTimes(1);
+
+			messagingClient.sendScheduledMessage.mockClear();
+
+			// 2e tick : pod B prend le lock (le notre a expire). La candidate query
+			// ne renvoie aucun nouveau PENDING, et meme si elle en renvoyait, l'UPDATE
+			// conditionne sur status=PENDING ne matcherait plus rien.
+			repository.find.mockResolvedValueOnce([]);
+			queryBuilder.execute.mockResolvedValueOnce({ raw: [] });
+
+			await service.processDueMessages();
+
+			expect(messagingClient.sendScheduledMessage).not.toHaveBeenCalled();
 		});
 
 		it('deux instances ont des owner IDs distincts (cas multi-pod)', async () => {

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThanOrEqual } from 'typeorm';
+import { Repository, In, LessThanOrEqual } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { ScheduledMessage, ScheduledMessageStatus } from '../entities/scheduled-message.entity';
@@ -14,6 +14,9 @@ import { buildRedisOptions } from '@/config/redis.config';
 
 const LOCK_KEY_PREFIX = 'scheduled-messages:lock:';
 const LOCK_TTL_SECONDS = 55;
+// Taille max d'un batch claim. Bornee pour eviter qu'un seul tick monopolise
+// la connexion DB et garder une latence d'envoi previsible.
+const PROCESS_BATCH_SIZE = 100;
 
 // Lua atomique : ne supprime la cle que si la valeur appartient a ce process.
 // Evite qu'un pod expire son lock et delete celui d'un autre pod.
@@ -166,21 +169,15 @@ export class ScheduledMessagesService {
 		}
 
 		try {
-			const dueMessages = await this.scheduledMessageRepository.find({
-				where: {
-					status: ScheduledMessageStatus.PENDING,
-					scheduledAt: LessThanOrEqual(new Date()),
-				},
-				order: { scheduledAt: 'ASC' },
-			});
+			const claimed = await this.claimDueMessages();
 
-			if (dueMessages.length === 0) {
+			if (claimed.length === 0) {
 				return;
 			}
 
-			this.logger.log(`Processing ${dueMessages.length} due scheduled message(s)`);
+			this.logger.log(`Processing ${claimed.length} due scheduled message(s)`);
 
-			for (const message of dueMessages) {
+			for (const message of claimed) {
 				await this.sendMessage(message);
 			}
 		} catch (error) {
@@ -191,6 +188,52 @@ export class ScheduledMessagesService {
 		} finally {
 			await this.releaseLock(lockKey);
 		}
+	}
+
+	/**
+	 * Claim atomique des messages dus :
+	 *  1. SELECT des IDs PENDING dont scheduledAt <= now (borne PROCESS_BATCH_SIZE).
+	 *  2. UPDATE ... SET status = PROCESSING WHERE id IN (...) AND status = PENDING
+	 *     RETURNING * — l'UPDATE pose un row-level lock cote PostgreSQL, donc deux
+	 *     pods ne peuvent pas claim le meme enregistrement.
+	 *
+	 * Si notre lock Redis expire en cours de boucle, le pod suivant ne verra plus
+	 * ces messages comme PENDING, donc ne les retraitera pas. Plus de double-send.
+	 */
+	private async claimDueMessages(): Promise<ScheduledMessage[]> {
+		const now = new Date();
+
+		const candidates = await this.scheduledMessageRepository.find({
+			where: {
+				status: ScheduledMessageStatus.PENDING,
+				scheduledAt: LessThanOrEqual(now),
+			},
+			order: { scheduledAt: 'ASC' },
+			take: PROCESS_BATCH_SIZE,
+			select: ['id'],
+		});
+
+		if (candidates.length === 0) {
+			return [];
+		}
+
+		const candidateIds = candidates.map((m) => m.id);
+
+		// UPDATE conditionne sur status=PENDING : si un autre process a deja claim
+		// la ligne, le predicat ne match plus et la ligne n'est pas retournee.
+		const claimResult = await this.scheduledMessageRepository
+			.createQueryBuilder()
+			.update(ScheduledMessage)
+			.set({ status: ScheduledMessageStatus.PROCESSING })
+			.where({
+				id: In(candidateIds),
+				status: ScheduledMessageStatus.PENDING,
+			})
+			.returning('*')
+			.execute();
+
+		const raw = (claimResult.raw ?? []) as ScheduledMessage[];
+		return this.scheduledMessageRepository.create(raw);
 	}
 
 	private async sendMessage(message: ScheduledMessage): Promise<void> {


### PR DESCRIPTION
## Contexte

Le cron `processDueMessages` acquiert un lock Redis avec TTL 55s puis itere sur N messages PENDING. Chaque iteration fait 1 gRPC call + 2 ecritures DB. Si N * latence > 55s, le lock expire pendant la boucle. Un autre pod prend le lock, voit les memes messages encore PENDING (ceux dont `sendMessage` a abouti mais dont le `save(SENT)` n'a pas encore commit), et les retraite. Resultat : messages envoyes 2 fois.

## Fix

Claim atomique au niveau base de donnees, pas seulement Redis :

1. SELECT IDs des messages PENDING dus (borne 100/tick).
2. UPDATE ... SET status = PROCESSING WHERE id IN (...) AND status = PENDING RETURNING *.

Le filtre `status = PENDING` dans le UPDATE garantit qu'un seul pod peut claim un enregistrement, meme si le lock Redis expire entre temps. Le 2e pod verra `status = PROCESSING` et ne retraitera pas la ligne.

Le lock Redis reste comme garde-fou anti-thundering-herd, mais sa correctness ne depend plus de son TTL.

## Changes

- `entities/scheduled-message.entity.ts` : ajout valeur `PROCESSING` dans l'enum.
- `migrations/...AddProcessingStatusScheduledMessages.ts` : `ALTER TYPE ... ADD VALUE IF NOT EXISTS`.
- `services/scheduled-messages.service.ts` : nouvelle methode `claimDueMessages()` + boucle sur le resultat.
- `services/scheduled-messages.service.spec.ts` : 2 nouveaux tests prouvant le claim atomique et le no-op sur lock expire.

## Test plan

- [x] Unit tests verts (92/92, 11/11 sur ce fichier)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Lint + prettier clean
- [x] Test "claim atomique : marque les messages PROCESSING avant envoi"
- [x] Test "lock expire : un 2e processDueMessages ne retraite pas les messages deja PROCESSING"
- [ ] Migration `processing` enum value applied successfully on preprod (verifier post-merge)

Closes WHISPR-1350