### PR TITLE
[WHISPR-1355] fix(scheduling): timezone-aware scheduledAt

### DIFF
--- a/src/common/decorators/is-iso8601-with-offset.decorator.spec.ts
+++ b/src/common/decorators/is-iso8601-with-offset.decorator.spec.ts
@@ -1,0 +1,52 @@
+import { validate } from 'class-validator';
+import { IsISO8601WithOffset } from './is-iso8601-with-offset.decorator';
+
+class Sample {
+	@IsISO8601WithOffset()
+	scheduledAt!: string;
+}
+
+const buildSample = (value: unknown): Sample => {
+	const s = new Sample();
+	(s as { scheduledAt: unknown }).scheduledAt = value;
+	return s;
+};
+
+describe('IsISO8601WithOffset', () => {
+	it.each([
+		'2026-05-09T09:00:00Z',
+		'2026-05-09T09:00:00+02:00',
+		'2026-05-09T09:00:00-05:00',
+		'2026-05-09T09:00:00.123+02:00',
+		'2026-12-31T23:59:59.999Z',
+	])('accepte %s', async (value) => {
+		const errors = await validate(buildSample(value));
+		expect(errors).toHaveLength(0);
+	});
+
+	it.each([
+		// Sans offset : c'est le bug WHISPR-1355.
+		['2026-05-09T09:00:00', 'datetime naive sans offset'],
+		['2026-05-09', 'date sans heure'],
+		['09:00:00Z', 'heure seule'],
+		['2026/05/09T09:00:00Z', 'separateur invalide'],
+		['', 'string vide'],
+		['not-a-date', 'pas un datetime'],
+		['2026-05-09T09:00:00+2:00', 'offset non zero-pad'],
+		['2026-05-09T09:00:00 +02:00', 'espace avant offset'],
+	])('rejette %s (%s)', async (value) => {
+		const errors = await validate(buildSample(value));
+		expect(errors).toHaveLength(1);
+		expect(errors[0].constraints?.isISO8601WithOffset).toMatch(/timezone offset/);
+	});
+
+	it.each<[unknown, string]>([
+		[null, 'null'],
+		[undefined, 'undefined'],
+		[123, 'number'],
+		[{}, 'object'],
+	])('rejette les non-string : %s (%s)', async (value) => {
+		const errors = await validate(buildSample(value));
+		expect(errors).toHaveLength(1);
+	});
+});

--- a/src/common/decorators/is-iso8601-with-offset.decorator.ts
+++ b/src/common/decorators/is-iso8601-with-offset.decorator.ts
@@ -1,0 +1,39 @@
+import { registerDecorator, ValidationArguments, ValidationOptions } from 'class-validator';
+
+// Format ISO 8601 avec offset timezone explicite (Z ou +HH:MM / -HH:MM).
+// On rejette les datetime naives type "2026-05-09T09:00:00" : sans offset,
+// new Date(...) interprete la string comme UTC dans Node, ce qui decale
+// l'envoi du message de plusieurs heures pour tout client en heure locale.
+const ISO_8601_WITH_OFFSET = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Valide qu'une string est ISO 8601 ET contient un offset timezone explicite.
+ * Accepte : "2026-05-09T09:00:00Z", "2026-05-09T09:00:00+02:00",
+ *           "2026-05-09T09:00:00.123-05:00".
+ * Rejette : "2026-05-09T09:00:00", "2026-05-09", "09:00".
+ */
+export function IsISO8601WithOffset(validationOptions?: ValidationOptions): PropertyDecorator {
+	return function (object: object, propertyName: string | symbol): void {
+		registerDecorator({
+			name: 'isISO8601WithOffset',
+			target: object.constructor,
+			propertyName: propertyName as string,
+			options: validationOptions,
+			validator: {
+				validate(value: unknown): boolean {
+					if (typeof value !== 'string') {
+						return false;
+					}
+					if (!ISO_8601_WITH_OFFSET.test(value)) {
+						return false;
+					}
+					// Sanity check : la string doit etre parseable en Date valide.
+					return !Number.isNaN(new Date(value).getTime());
+				},
+				defaultMessage(args: ValidationArguments): string {
+					return `${args.property} must be an ISO 8601 datetime with explicit timezone offset (e.g. 2026-05-09T09:00:00+02:00 or 2026-05-09T09:00:00Z)`;
+				},
+			},
+		});
+	};
+}

--- a/src/modules/app/migrations/1746830000000-AlterScheduledMessagesTimestamptz.ts
+++ b/src/modules/app/migrations/1746830000000-AlterScheduledMessagesTimestamptz.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Bascule scheduled_at, created_at, updated_at de TIMESTAMP (sans tz) vers
+ * TIMESTAMPTZ. Sans cette colonne timezone-aware, l'envoi des messages
+ * programmes pouvait deriver d'1-2h selon l'heure d'ete et le timezone de
+ * session PostgreSQL (cf WHISPR-1355).
+ *
+ * Les valeurs deja persistees sont interpretees comme UTC : les ecritures
+ * passees venaient de `new Date(dto.scheduledAt)` cote service Node, qui
+ * sans offset traite la string comme UTC. On preserve donc l'instant absolu.
+ */
+export class AlterScheduledMessagesTimestamptz1746830000000 implements MigrationInterface {
+	name = 'AlterScheduledMessagesTimestamptz1746830000000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TABLE "scheduled_messages"
+				ALTER COLUMN "scheduled_at" TYPE TIMESTAMPTZ USING "scheduled_at" AT TIME ZONE 'UTC'`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "scheduled_messages"
+				ALTER COLUMN "created_at" TYPE TIMESTAMPTZ USING "created_at" AT TIME ZONE 'UTC'`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "scheduled_messages"
+				ALTER COLUMN "updated_at" TYPE TIMESTAMPTZ USING "updated_at" AT TIME ZONE 'UTC'`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TABLE "scheduled_messages"
+				ALTER COLUMN "scheduled_at" TYPE TIMESTAMP USING "scheduled_at" AT TIME ZONE 'UTC'`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "scheduled_messages"
+				ALTER COLUMN "created_at" TYPE TIMESTAMP USING "created_at" AT TIME ZONE 'UTC'`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "scheduled_messages"
+				ALTER COLUMN "updated_at" TYPE TIMESTAMP USING "updated_at" AT TIME ZONE 'UTC'`
+		);
+	}
+}

--- a/src/modules/scheduled-messages/dto/create-scheduled-message.dto.ts
+++ b/src/modules/scheduled-messages/dto/create-scheduled-message.dto.ts
@@ -1,5 +1,6 @@
-import { IsString, IsNotEmpty, IsOptional, IsUUID, IsDateString, IsObject } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsUUID, IsObject } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsISO8601WithOffset } from '@/common/decorators/is-iso8601-with-offset.decorator';
 
 export class CreateScheduledMessageDto {
 	@ApiProperty({
@@ -27,10 +28,11 @@ export class CreateScheduledMessageDto {
 	metadata?: Record<string, any>;
 
 	@ApiProperty({
-		description: 'When the message should be sent (ISO 8601 format, must be in the future)',
-		example: '2026-04-15T10:00:00Z',
+		description:
+			'When the message should be sent (ISO 8601 with explicit timezone offset, must be in the future)',
+		example: '2026-04-15T10:00:00+02:00',
 	})
-	@IsDateString()
+	@IsISO8601WithOffset()
 	@IsNotEmpty()
 	scheduledAt: string;
 }

--- a/src/modules/scheduled-messages/dto/update-scheduled-message.dto.ts
+++ b/src/modules/scheduled-messages/dto/update-scheduled-message.dto.ts
@@ -1,5 +1,6 @@
-import { IsString, IsOptional, IsDateString, IsObject } from 'class-validator';
+import { IsString, IsOptional, IsObject } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsISO8601WithOffset } from '@/common/decorators/is-iso8601-with-offset.decorator';
 
 export class UpdateScheduledMessageDto {
 	@ApiPropertyOptional({
@@ -19,10 +20,10 @@ export class UpdateScheduledMessageDto {
 	metadata?: Record<string, any>;
 
 	@ApiPropertyOptional({
-		description: 'Updated scheduled time (ISO 8601 format, must be in the future)',
-		example: '2026-04-20T14:00:00Z',
+		description: 'Updated scheduled time (ISO 8601 with explicit timezone offset, must be in the future)',
+		example: '2026-04-20T14:00:00+02:00',
 	})
 	@IsOptional()
-	@IsDateString()
+	@IsISO8601WithOffset()
 	scheduledAt?: string;
 }

--- a/src/modules/scheduled-messages/entities/scheduled-message.entity.ts
+++ b/src/modules/scheduled-messages/entities/scheduled-message.entity.ts
@@ -31,7 +31,10 @@ export class ScheduledMessage {
 	@Column({ type: 'jsonb', nullable: true, default: null })
 	metadata: Record<string, any> | null;
 
-	@Column({ type: 'timestamp', name: 'scheduled_at' })
+	// timestamptz : on stocke l'instant absolu UTC. Le DTO impose un offset
+	// timezone explicite cote API (cf is-iso8601-with-offset.decorator), donc
+	// `new Date(dto.scheduledAt)` produit toujours le bon instant.
+	@Column({ type: 'timestamptz', name: 'scheduled_at' })
 	scheduledAt: Date;
 
 	@Column({
@@ -41,9 +44,9 @@ export class ScheduledMessage {
 	})
 	status: ScheduledMessageStatus;
 
-	@CreateDateColumn({ name: 'created_at', type: 'timestamp' })
+	@CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
 	createdAt: Date;
 
-	@UpdateDateColumn({ name: 'updated_at', type: 'timestamp' })
+	@UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
 	updatedAt: Date;
 }

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
@@ -125,6 +125,27 @@ describe('ScheduledMessagesService', () => {
 				})
 			).rejects.toThrow('scheduled_at must be in the future');
 		});
+
+		it('preserve l instant absolu UTC pour un offset Paris ete (+02:00)', async () => {
+			// 09:00 Paris ete = 07:00 UTC. Le service doit persister 07:00Z.
+			// L'horizon doit etre largement futur pour ne pas declencher la
+			// validation "date passee" peu importe le moment d'execution du test.
+			const farFuture = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+			const yyyy = farFuture.getUTCFullYear();
+			const mm = String(farFuture.getUTCMonth() + 1).padStart(2, '0');
+			const dd = String(farFuture.getUTCDate()).padStart(2, '0');
+			const scheduledAt = `${yyyy}-${mm}-${dd}T09:00:00+02:00`;
+
+			await service.create('uid', {
+				conversationId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+				content: 'hello',
+				scheduledAt,
+			});
+
+			const persistedDate = repository.create.mock.calls[0][0].scheduledAt as Date;
+			expect(persistedDate.getUTCHours()).toBe(7);
+			expect(persistedDate.getUTCMinutes()).toBe(0);
+		});
 	});
 
 	describe('findOne / update / cancel — scoping par userId', () => {


### PR DESCRIPTION
## Summary
- Rejette les datetime naives sans offset (`2026-05-09T09:00:00`) avec un 400 BadRequest explicite. Avant le fix, `new Date(...)` cote service interpretait ces strings comme UTC, decalant l'envoi de 1-2h selon le timezone du client (ex: `09:00` Paris ete envoyait a `11:00` au lieu de `09:00`).
- Ajoute un decorateur `@IsISO8601WithOffset()` (regex stricte sur `Z` ou `+HH:MM` final) applique aux DTO create + update.
- Bascule les colonnes `scheduled_at`, `created_at`, `updated_at` de `TIMESTAMP` vers `TIMESTAMPTZ` (migration `1746830000000`) pour stocker l'instant absolu.

## Test plan
- [x] 17 tests unitaires sur le decorateur (accepte `Z`, `+02:00`, `-05:00`, fractions ; rejette naive, date seule, separateur invalide, non-string)
- [x] Test service : un scheduledAt `09:00+02:00` se persiste bien a `07:00 UTC`
- [x] Suite complete : 110/110 tests verts
- [x] Lint + typecheck propres

Closes WHISPR-1355