### PR TITLE
[WHISPR-1367] fix(scheduling): defense-in-depth ownership service-level

### DIFF
--- a/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
@@ -172,6 +172,21 @@ describe('ScheduledMessagesService', () => {
 				where: { id: 'msg-id', userId: 'user-A' },
 			});
 		});
+
+		it('un autre userId que le proprietaire recoit NotFoundException (pas de leak owner)', async () => {
+			// le repo renvoie null car la query { id, userId=attaquant } ne match aucune ligne
+			repository.findOne.mockResolvedValue(null);
+			await expect(service.findOne('msg-owned-by-bob', 'attacker-id')).rejects.toThrow('not found');
+			expect(repository.findOne).toHaveBeenCalledWith({
+				where: { id: 'msg-owned-by-bob', userId: 'attacker-id' },
+			});
+		});
+
+		it('userId vide est rejete avant la query DB (defense-in-depth contre transport sans JWT)', async () => {
+			await expect(service.update('msg-id', '', { content: 'x' })).rejects.toThrow('not found');
+			// la query DB ne doit jamais etre lancee si le caller n'a pas de userId
+			expect(repository.findOne).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('processDueMessages — Redis lock', () => {

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.ts
@@ -80,14 +80,7 @@ export class ScheduledMessagesService {
 	}
 
 	async findOne(id: string, userId: string): Promise<ScheduledMessageResponseDto> {
-		const message = await this.scheduledMessageRepository.findOne({
-			where: { id, userId },
-		});
-
-		if (!message) {
-			throw new NotFoundException(`Scheduled message with ID ${id} not found`);
-		}
-
+		const message = await this.findOwnedOrThrow(id, userId);
 		return this.toResponse(message);
 	}
 
@@ -96,13 +89,7 @@ export class ScheduledMessagesService {
 		userId: string,
 		dto: UpdateScheduledMessageDto
 	): Promise<ScheduledMessageResponseDto> {
-		const message = await this.scheduledMessageRepository.findOne({
-			where: { id, userId },
-		});
-
-		if (!message) {
-			throw new NotFoundException(`Scheduled message with ID ${id} not found`);
-		}
+		const message = await this.findOwnedOrThrow(id, userId);
 
 		if (message.status !== ScheduledMessageStatus.PENDING) {
 			throw new BadRequestException(
@@ -134,13 +121,7 @@ export class ScheduledMessagesService {
 	}
 
 	async cancel(id: string, userId: string): Promise<void> {
-		const message = await this.scheduledMessageRepository.findOne({
-			where: { id, userId },
-		});
-
-		if (!message) {
-			throw new NotFoundException(`Scheduled message with ID ${id} not found`);
-		}
+		const message = await this.findOwnedOrThrow(id, userId);
 
 		if (message.status !== ScheduledMessageStatus.PENDING) {
 			throw new BadRequestException(
@@ -152,6 +133,29 @@ export class ScheduledMessagesService {
 		await this.scheduledMessageRepository.save(message);
 
 		this.logger.log('Scheduled message cancelled', { id: message.id });
+	}
+
+	/**
+	 * Defense-in-depth : verifie l'ownership cote service, peu importe le transport.
+	 * Si demain ce service est appele par un handler gRPC ou un event listener qui
+	 * oublie de scoper, on n'expose pas une IDOR. Le predicat SQL { id, userId }
+	 * fait le boulot, et un userId vide est traite comme un not-found pour eviter
+	 * qu'un appelant sans contexte JWT ne puisse passer un id seul.
+	 */
+	private async findOwnedOrThrow(id: string, userId: string): Promise<ScheduledMessage> {
+		if (!userId) {
+			throw new NotFoundException(`Scheduled message with ID ${id} not found`);
+		}
+
+		const message = await this.scheduledMessageRepository.findOne({
+			where: { id, userId },
+		});
+
+		if (!message) {
+			throw new NotFoundException(`Scheduled message with ID ${id} not found`);
+		}
+
+		return message;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Centralise le check d'ownership du `ScheduledMessage` dans un helper prive `findOwnedOrThrow(id, userId)` reutilise par `findOne`, `update`, `cancel`.
- Premier acte du helper : reject d'un `userId` vide avant la query DB. Defense-in-depth contre un futur transport qui appellerait le service sans avoir extrait le userId du JWT (gRPC handler, event listener, scheduled job).
- Deuxieme acte : `findOne({ where: { id, userId } })` -> `NotFoundException` si null.
- Garde la meme reponse `404 NotFound` pour ne pas leak l'existence de la ressource a un attaquant.

WHISPR-1317 avait deja fixe l'IDOR cote controller (JWT -> userId, plus de body trust). Ce PR ajoute la couche service pour qu'un nouveau transport ne puisse pas regresser le check.

## Test plan

- [x] Unit tests verts (112/112)
- [x] Lint clean
- [x] Test "wrong userId -> NotFoundException" couvre le scenario IDOR
- [x] Test "userId vide -> NotFoundException avant query DB" couvre le cas transport sans JWT
- [ ] CI green

Closes WHISPR-1367