### PR TITLE
[WHISPR-1376] fix(scheduling): env fail-closed + onDelete explicite

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,8 @@ async function bootstrap() {
 	// WHISPR-1348 : entêtes de sécurité HTTP (CSP, HSTS, X-Frame-Options, etc.)
 	// alignés sur auth-service / user-service / media-service. CSP désactivée
 	// quand Swagger est servi en non-prod pour ne pas bloquer le SwaggerUI inline.
-	const swaggerEnabled = configService.get('SWAGGER_ENABLED', 'true') === 'true';
+	// fail-closed: Swagger OFF par defaut, opt-in explicite via SWAGGER_ENABLED=true
+	const swaggerEnabled = configService.get('SWAGGER_ENABLED', 'false') === 'true';
 	app.use(
 		helmet({
 			contentSecurityPolicy: swaggerEnabled
@@ -41,8 +42,8 @@ async function bootstrap() {
 		})
 	);
 
-	// Enable CORS if configured
-	if (configService.get('CORS_ENABLED', 'true') === 'true') {
+	// fail-closed: CORS OFF par defaut, opt-in explicite via CORS_ENABLED=true
+	if (configService.get('CORS_ENABLED', 'false') === 'true') {
 		const rawOrigins = configService.get<string>('CORS_ALLOWED_ORIGINS', '');
 		const allowedOrigins = rawOrigins
 			.split(',')

--- a/src/modules/app/migrations/1746900000000-JobsCategoryFkSetNull.ts
+++ b/src/modules/app/migrations/1746900000000-JobsCategoryFkSetNull.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Bascule la FK jobs.category_id de NO ACTION vers SET NULL et rend la
+ * colonne nullable. Sans ca, supprimer une JobCategory cassait la contrainte
+ * FK et orphelinait les jobs lies. Avec SET NULL on garde les jobs (audit
+ * trail) et categoryId passe a NULL automatiquement.
+ */
+export class JobsCategoryFkSetNull1746900000000 implements MigrationInterface {
+	name = 'JobsCategoryFkSetNull1746900000000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "jobs" DROP CONSTRAINT "FK_jobs_category_id"`);
+		await queryRunner.query(`ALTER TABLE "jobs" ALTER COLUMN "category_id" DROP NOT NULL`);
+		await queryRunner.query(
+			`ALTER TABLE "jobs" ADD CONSTRAINT "FK_jobs_category_id" FOREIGN KEY ("category_id") REFERENCES "job_categories"("id") ON DELETE SET NULL ON UPDATE NO ACTION`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "jobs" DROP CONSTRAINT "FK_jobs_category_id"`);
+		// Pour revenir a NOT NULL il faut d'abord traiter les eventuels NULL
+		// generes par le SET NULL (sinon ALTER echoue).
+		await queryRunner.query(`DELETE FROM "jobs" WHERE "category_id" IS NULL`);
+		await queryRunner.query(`ALTER TABLE "jobs" ALTER COLUMN "category_id" SET NOT NULL`);
+		await queryRunner.query(
+			`ALTER TABLE "jobs" ADD CONSTRAINT "FK_jobs_category_id" FOREIGN KEY ("category_id") REFERENCES "job_categories"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+		);
+	}
+}

--- a/src/modules/grpc/services/grpc-scheduler.service.ts
+++ b/src/modules/grpc/services/grpc-scheduler.service.ts
@@ -194,7 +194,9 @@ export class GrpcSchedulerService {
 			id: job.id,
 			name: job.name,
 			description: job.description,
-			categoryId: job.categoryId,
+			// proto3 string ne supporte pas null: on remplace par '' si la
+			// categorie a ete supprimee (FK SET NULL)
+			categoryId: job.categoryId ?? '',
 			targetService: job.targetService,
 			targetMethod: job.targetMethod,
 			payload: JSON.stringify(job.payload),

--- a/src/modules/scheduler/dto/job-response.dto.ts
+++ b/src/modules/scheduler/dto/job-response.dto.ts
@@ -21,10 +21,11 @@ export class JobResponseDto {
 	description?: string;
 
 	@ApiProperty({
-		description: 'Category ID',
+		description: 'Category ID (null si la categorie a ete supprimee)',
 		example: 'e7f8a9b0-1234-5678-9abc-def012345678',
+		nullable: true,
 	})
-	categoryId: string;
+	categoryId: string | null;
 
 	@ApiProperty({
 		description: 'Target service',

--- a/src/modules/scheduler/entities/job.entity.ts
+++ b/src/modules/scheduler/entities/job.entity.ts
@@ -30,8 +30,10 @@ export class Job {
 	@Column({ type: 'text', nullable: true })
 	description: string | null;
 
-	@Column({ type: 'uuid', name: 'category_id' })
-	categoryId: string;
+	// nullable pour permettre ON DELETE SET NULL: les jobs survivent a la
+	// suppression de leur categorie (audit trail conserve)
+	@Column({ type: 'uuid', name: 'category_id', nullable: true })
+	categoryId: string | null;
 
 	@Column({ type: 'varchar', length: 100, name: 'target_service' })
 	targetService: string;
@@ -67,9 +69,14 @@ export class Job {
 	deletedAt: Date | null;
 
 	// Relations
-	@ManyToOne(() => JobCategory, (category) => category.jobs)
+	// onDelete SET NULL: si la categorie est supprimee, on garde le job
+	// (audit trail) et categoryId passe a NULL
+	@ManyToOne(() => JobCategory, (category) => category.jobs, {
+		onDelete: 'SET NULL',
+		nullable: true,
+	})
 	@JoinColumn({ name: 'category_id' })
-	category: JobCategory;
+	category: JobCategory | null;
 
 	@OneToMany(() => Schedule, (schedule) => schedule.job, { cascade: true })
 	schedules: Schedule[];


### PR DESCRIPTION
## Summary
- main.ts: SWAGGER_ENABLED et CORS_ENABLED en fail-closed (defaut OFF, opt-in explicite)
- job.entity.ts: ManyToOne categorie en onDelete SET NULL + categoryId nullable (audit trail conserve si categorie supprimee)
- Migration FK_jobs_category_id : DROP CONSTRAINT, DROP NOT NULL, ADD CONSTRAINT ON DELETE SET NULL
- DTO et mapping gRPC ajustes pour le nullable (proto3 string -> '' si null)

## Test plan
- [x] Unit tests verts (112 passed)
- [x] Typecheck propre
- [x] Lint + prettier clean
- [ ] CI deploy/preprod vert
- [ ] Migration replay sur preprod

Closes WHISPR-1376