### PR TITLE
[WHISPR-1383] fix(scheduling): retry transient errors avant FAILED

### DIFF
--- a/src/modules/app/migrations/1746950000000-AddRetryCountScheduledMessages.ts
+++ b/src/modules/app/migrations/1746950000000-AddRetryCountScheduledMessages.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Ajoute la colonne retry_count sur scheduled_messages.
+ * Sert a compter les echecs transients (timeout, 5xx, ECONNREFUSED) avant
+ * de basculer le message en FAILED definitif. Permet aux pannes momentanees
+ * de messaging-service de ne pas perdre les messages programmes.
+ */
+export class AddRetryCountScheduledMessages1746950000000 implements MigrationInterface {
+	name = 'AddRetryCountScheduledMessages1746950000000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TABLE "scheduled_messages" ADD COLUMN IF NOT EXISTS "retry_count" integer NOT NULL DEFAULT 0`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "scheduled_messages" DROP COLUMN IF EXISTS "retry_count"`);
+	}
+}

--- a/src/modules/scheduled-messages/entities/scheduled-message.entity.ts
+++ b/src/modules/scheduled-messages/entities/scheduled-message.entity.ts
@@ -44,6 +44,12 @@ export class ScheduledMessage {
 	})
 	status: ScheduledMessageStatus;
 
+	// Compteur d'echecs transients (timeout, 5xx, ECONNREFUSED, etc).
+	// Au dela de RETRY_LIMIT, le message bascule en FAILED definitif.
+	// Une erreur permanente (4xx hors 408/429/503/504) court-circuite ce compteur.
+	@Column({ type: 'int', name: 'retry_count', default: 0 })
+	retryCount: number;
+
 	@CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
 	createdAt: Date;
 

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
@@ -307,6 +307,112 @@ describe('ScheduledMessagesService', () => {
 			expect(messagingClient.sendScheduledMessage).not.toHaveBeenCalled();
 		});
 
+		describe('sendMessage — retry sur erreur transiente', () => {
+			// Construit un message PENDING fake, dejà claim par claimDueMessages
+			// (donc en PROCESSING avec retryCount=initial).
+			const buildClaimed = (overrides: Partial<ScheduledMessage> = {}): ScheduledMessage =>
+				({
+					id: 'msg-retry',
+					userId: 'u',
+					conversationId: 'c',
+					content: 'hello',
+					metadata: null,
+					scheduledAt: new Date(Date.now() - 1000),
+					status: ScheduledMessageStatus.PROCESSING,
+					retryCount: 0,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					...overrides,
+				}) as ScheduledMessage;
+
+			beforeEach(() => {
+				redisMock.set.mockResolvedValue('OK');
+				redisMock.runScript.mockResolvedValue(1);
+			});
+
+			it('erreur transiente (ECONNREFUSED) repasse status=PENDING + increment retry_count', async () => {
+				const claimed = buildClaimed({ retryCount: 0 });
+				repository.find.mockResolvedValue([{ id: claimed.id }]);
+				queryBuilder.execute.mockResolvedValue({ raw: [claimed] });
+
+				const transientError = Object.assign(new Error('connection refused'), {
+					code: 'ECONNREFUSED',
+				});
+				messagingClient.sendScheduledMessage.mockRejectedValue(transientError);
+
+				await service.processDueMessages();
+
+				const savedStates = repository.save.mock.calls.map((call) => call[0]);
+				const lastSave = savedStates[savedStates.length - 1];
+				expect(lastSave.status).toBe(ScheduledMessageStatus.PENDING);
+				expect(lastSave.retryCount).toBe(1);
+			});
+
+			it('erreur 503 (transiente) repasse en PENDING avec retryCount+1', async () => {
+				const claimed = buildClaimed({ retryCount: 1 });
+				repository.find.mockResolvedValue([{ id: claimed.id }]);
+				queryBuilder.execute.mockResolvedValue({ raw: [claimed] });
+
+				const httpError = Object.assign(new Error('service unavailable'), {
+					response: { status: 503 },
+				});
+				messagingClient.sendScheduledMessage.mockRejectedValue(httpError);
+
+				await service.processDueMessages();
+
+				const lastSave = repository.save.mock.calls.at(-1)?.[0];
+				expect(lastSave.status).toBe(ScheduledMessageStatus.PENDING);
+				expect(lastSave.retryCount).toBe(2);
+			});
+
+			it('erreur 400 (permanente) bascule directement en FAILED sans retry', async () => {
+				const claimed = buildClaimed({ retryCount: 0 });
+				repository.find.mockResolvedValue([{ id: claimed.id }]);
+				queryBuilder.execute.mockResolvedValue({ raw: [claimed] });
+
+				const validationError = Object.assign(new Error('invalid payload'), {
+					response: { status: 400 },
+				});
+				messagingClient.sendScheduledMessage.mockRejectedValue(validationError);
+
+				await service.processDueMessages();
+
+				const lastSave = repository.save.mock.calls.at(-1)?.[0];
+				expect(lastSave.status).toBe(ScheduledMessageStatus.FAILED);
+				expect(lastSave.retryCount).toBe(0);
+			});
+
+			it('3eme retry transient atteint le cap : status=FAILED', async () => {
+				const claimed = buildClaimed({ retryCount: 3 });
+				repository.find.mockResolvedValue([{ id: claimed.id }]);
+				queryBuilder.execute.mockResolvedValue({ raw: [claimed] });
+
+				const transientError = Object.assign(new Error('reset'), {
+					code: 'ECONNRESET',
+				});
+				messagingClient.sendScheduledMessage.mockRejectedValue(transientError);
+
+				await service.processDueMessages();
+
+				const lastSave = repository.save.mock.calls.at(-1)?.[0];
+				expect(lastSave.status).toBe(ScheduledMessageStatus.FAILED);
+				expect(lastSave.retryCount).toBe(3);
+			});
+
+			it('succes apres claim : status=SENT, pas de bump retry_count', async () => {
+				const claimed = buildClaimed({ retryCount: 1 });
+				repository.find.mockResolvedValue([{ id: claimed.id }]);
+				queryBuilder.execute.mockResolvedValue({ raw: [claimed] });
+				messagingClient.sendScheduledMessage.mockResolvedValue({ ok: true });
+
+				await service.processDueMessages();
+
+				const lastSave = repository.save.mock.calls.at(-1)?.[0];
+				expect(lastSave.status).toBe(ScheduledMessageStatus.SENT);
+				expect(lastSave.retryCount).toBe(1);
+			});
+		});
+
 		it('deux instances ont des owner IDs distincts (cas multi-pod)', async () => {
 			redisMock.set.mockResolvedValue('OK');
 			redisMock.runScript.mockResolvedValue(1);

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.ts
@@ -17,6 +17,24 @@ const LOCK_TTL_SECONDS = 55;
 // Taille max d'un batch claim. Bornee pour eviter qu'un seul tick monopolise
 // la connexion DB et garder une latence d'envoi previsible.
 const PROCESS_BATCH_SIZE = 100;
+// Plafond de retry sur erreur transiente avant de basculer en FAILED definitif.
+// 3 tentatives = ~3 minutes de tolerance (cron par minute), suffisant pour
+// absorber un redeploiement messaging-service ou une coupure reseau breve.
+const RETRY_LIMIT = 3;
+// Codes HTTP consideres comme transients (le retry a une chance de reussir).
+// 408 timeout, 429 throttling, 503 unavailable, 504 gateway timeout.
+const TRANSIENT_HTTP_STATUS = new Set([408, 429, 502, 503, 504]);
+// Codes erreur reseau Node consideres comme transients.
+const TRANSIENT_NETWORK_CODES = new Set([
+	'ECONNREFUSED',
+	'ECONNRESET',
+	'ETIMEDOUT',
+	'EAI_AGAIN',
+	'ENOTFOUND',
+	'EPIPE',
+]);
+// Codes gRPC transients : UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, ABORTED.
+const TRANSIENT_GRPC_CODES = new Set([4, 8, 10, 14]);
 
 // Lua atomique : ne supprime la cle que si la valeur appartient a ce process.
 // Evite qu'un pod expire son lock et delete celui d'un autre pod.
@@ -259,14 +277,85 @@ export class ScheduledMessagesService {
 				conversationId: message.conversationId,
 			});
 		} catch (error) {
+			const transient = this.isTransientError(error);
+			const canRetry = transient && message.retryCount < RETRY_LIMIT;
+
+			if (canRetry) {
+				// On ramene le message en PENDING pour que le prochain tick
+				// le re-claim. Increment du compteur pour cap les retries.
+				message.retryCount += 1;
+				message.status = ScheduledMessageStatus.PENDING;
+				await this.scheduledMessageRepository.save(message);
+
+				this.logger.warn('Scheduled message send failed (transient), will retry', {
+					id: message.id,
+					retryCount: message.retryCount,
+					retryLimit: RETRY_LIMIT,
+					error: error.message,
+				});
+				return;
+			}
+
 			message.status = ScheduledMessageStatus.FAILED;
 			await this.scheduledMessageRepository.save(message);
 
 			this.logger.error('Failed to send scheduled message', {
 				id: message.id,
+				retryCount: message.retryCount,
+				transient,
 				error: error.message,
 			});
 		}
+	}
+
+	/**
+	 * Heuristique pour distinguer une erreur transiente d'une erreur permanente.
+	 * Transient : timeout, 5xx, ECONNREFUSED, ECONNRESET, gRPC UNAVAILABLE, etc.
+	 * Permanent : 4xx (hors 408/429), validation, user inconnu.
+	 * Si on ne reconnait pas le format, on prend le parti prudent du "transient"
+	 * pour ne pas perdre silencieusement un message sur une exception inhabituelle.
+	 */
+	private isTransientError(error: unknown): boolean {
+		if (!error || typeof error !== 'object') {
+			return true;
+		}
+
+		const err = error as {
+			code?: string | number;
+			status?: number;
+			statusCode?: number;
+			response?: { status?: number };
+		};
+
+		// Erreur reseau Node (ECONNREFUSED, ECONNRESET, ETIMEDOUT...).
+		if (typeof err.code === 'string' && TRANSIENT_NETWORK_CODES.has(err.code)) {
+			return true;
+		}
+
+		// gRPC status code numerique.
+		if (typeof err.code === 'number' && TRANSIENT_GRPC_CODES.has(err.code)) {
+			return true;
+		}
+
+		// HTTP status (axios met response.status, certains clients mettent status/statusCode).
+		const httpStatus = err.response?.status ?? err.status ?? err.statusCode;
+		if (typeof httpStatus === 'number') {
+			if (TRANSIENT_HTTP_STATUS.has(httpStatus)) {
+				return true;
+			}
+			// 4xx (hors transients deja matches) = permanent : payload invalide,
+			// user inconnu, droits manquants — un retry n'aidera pas.
+			if (httpStatus >= 400 && httpStatus < 500) {
+				return false;
+			}
+			// 5xx restant : transient par defaut.
+			if (httpStatus >= 500) {
+				return true;
+			}
+		}
+
+		// Format inconnu : on tolere un retry plutot que de perdre le message.
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Resume
- Le service `sendMessage` du scheduled-messages basculait n'importe quelle erreur en `FAILED`. Resultat : si messaging-service repond 503 ou ECONNREFUSED 30s pendant un redeploiement, le message scheduled de l'user est perdu silencieusement.
- Ajout d'un compteur `retry_count` (default 0) sur l'entite + migration TypeORM. Sur erreur transiente (5xx, ECONNREFUSED, ECONNRESET, ETIMEDOUT, gRPC UNAVAILABLE/DEADLINE_EXCEEDED), le message repasse `PENDING` et `retry_count` est incremente. Le prochain tick cron le re-claim normalement.
- Cap a 3 retries avant `FAILED` definitif (~3 minutes de tolerance).
- Erreurs permanentes (4xx hors 408/429) basculent direct en `FAILED` sans retry — pas la peine de boucler sur un payload invalide.

## Behavior change
- Avant : 1 erreur = message perdu.
- Apres : tolere 3 echecs transients avant de declarer le message FAILED.

## Test plan
- [x] Unit tests : 5 nouveaux scenarios (transient ECONNREFUSED, transient 503, permanent 400, cap 3 atteint, succes).
- [x] Suite complete : 117/117 verts.
- [x] Lint + prettier propres.
- [x] tsc --noEmit clean.

Closes WHISPR-1383