### PR TITLE
[WHISPR-1389] fix(scheduling): isTransientError fail-closed + 404 permanent

### DIFF
--- a/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.spec.ts
@@ -382,6 +382,38 @@ describe('ScheduledMessagesService', () => {
 				expect(lastSave.retryCount).toBe(0);
 			});
 
+			it('erreur 404 (conversation supprimee) bascule en FAILED sans retry', async () => {
+				const claimed = buildClaimed({ retryCount: 0 });
+				repository.find.mockResolvedValue([{ id: claimed.id }]);
+				queryBuilder.execute.mockResolvedValue({ raw: [claimed] });
+
+				const notFoundError = Object.assign(new Error('conversation not found'), {
+					response: { status: 404 },
+				});
+				messagingClient.sendScheduledMessage.mockRejectedValue(notFoundError);
+
+				await service.processDueMessages();
+
+				const lastSave = repository.save.mock.calls.at(-1)?.[0];
+				expect(lastSave.status).toBe(ScheduledMessageStatus.FAILED);
+				expect(lastSave.retryCount).toBe(0);
+			});
+
+			it('erreur shape inconnue (fail-closed) bascule en FAILED sans retry', async () => {
+				const claimed = buildClaimed({ retryCount: 0 });
+				repository.find.mockResolvedValue([{ id: claimed.id }]);
+				queryBuilder.execute.mockResolvedValue({ raw: [claimed] });
+
+				// Erreur sans code/status/response : doit etre traitee comme permanent.
+				messagingClient.sendScheduledMessage.mockRejectedValue(new Error('boom'));
+
+				await service.processDueMessages();
+
+				const lastSave = repository.save.mock.calls.at(-1)?.[0];
+				expect(lastSave.status).toBe(ScheduledMessageStatus.FAILED);
+				expect(lastSave.retryCount).toBe(0);
+			});
+
 			it('3eme retry transient atteint le cap : status=FAILED', async () => {
 				const claimed = buildClaimed({ retryCount: 3 });
 				repository.find.mockResolvedValue([{ id: claimed.id }]);

--- a/src/modules/scheduled-messages/services/scheduled-messages.service.ts
+++ b/src/modules/scheduled-messages/services/scheduled-messages.service.ts
@@ -311,13 +311,12 @@ export class ScheduledMessagesService {
 	/**
 	 * Heuristique pour distinguer une erreur transiente d'une erreur permanente.
 	 * Transient : timeout, 5xx, ECONNREFUSED, ECONNRESET, gRPC UNAVAILABLE, etc.
-	 * Permanent : 4xx (hors 408/429), validation, user inconnu.
-	 * Si on ne reconnait pas le format, on prend le parti prudent du "transient"
-	 * pour ne pas perdre silencieusement un message sur une exception inhabituelle.
+	 * Permanent : 4xx (404 conversation deleted, 410 gone, validation, user inconnu).
+	 * fail-closed: shape inconnue = traiter comme permanent (eviter retry storm).
 	 */
 	private isTransientError(error: unknown): boolean {
 		if (!error || typeof error !== 'object') {
-			return true;
+			return false;
 		}
 
 		const err = error as {
@@ -340,6 +339,10 @@ export class ScheduledMessagesService {
 		// HTTP status (axios met response.status, certains clients mettent status/statusCode).
 		const httpStatus = err.response?.status ?? err.status ?? err.statusCode;
 		if (typeof httpStatus === 'number') {
+			// 404 conversation deleted / 410 gone : permanent explicite, jamais retry.
+			if (httpStatus === 404 || httpStatus === 410) {
+				return false;
+			}
 			if (TRANSIENT_HTTP_STATUS.has(httpStatus)) {
 				return true;
 			}
@@ -354,8 +357,8 @@ export class ScheduledMessagesService {
 			}
 		}
 
-		// Format inconnu : on tolere un retry plutot que de perdre le message.
-		return true;
+		// fail-closed: shape inconnue = traiter comme permanent (eviter retry storm).
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Follow-up de WHISPR-1383 (retry logic). Le fallback de `isTransientError` retournait `true` (transient) sur shape inconnue, ce qui pouvait causer des retry storms si messaging-service renvoyait une erreur dans un format inattendu. De plus, un 404 (conversation supprimee) ou 410 (gone) sont maintenant explicitement classifies comme permanent.

### Changements

- Fallback fail-closed : shape inconnue = permanent (FAILED apres premier echec, pas de retry).
- 404 / 410 explicitement permanents (court-circuit avant le check 4xx generique).
- Garde toute la logique transient existante : 5xx / 408 / 429 / 502 / 503 / 504 / ECONNREFUSED / ECONNRESET / ETIMEDOUT / gRPC UNAVAILABLE.

### Test plan

- [x] Test mock 404 -> assert FAILED, retryCount=0.
- [x] Test mock shape inconnue (`new Error('boom')`) -> assert FAILED, retryCount=0.
- [x] Test mock 503 toujours transient (existant).
- [x] Test mock 400 toujours permanent (existant).
- [x] Lint + prettier clean.
- [x] 119 tests verts.

Closes WHISPR-1389