### PR TITLE
[WHISPR-1396] fix(queues): Bull concurrency + maxStalledCount

### DIFF
--- a/src/modules/queues/processors/job.processor.spec.ts
+++ b/src/modules/queues/processors/job.processor.spec.ts
@@ -1,0 +1,90 @@
+import 'reflect-metadata';
+
+// le setup global mock @nestjs/bullmq pour les autres specs.
+// ici on veut le vrai pour pouvoir lire les metadata posees par les decorateurs.
+jest.unmock('@nestjs/bullmq');
+
+const PROCESSOR_METADATA = 'bullmq:processor_metadata';
+const WORKER_METADATA = 'bullmq:worker_metadata';
+
+// helper: charge le module avec un BULL_CONCURRENCY donne
+function loadProcessorsWithEnv(envValue: string | undefined): {
+	HighPriorityJobProcessor: any;
+	MediumPriorityJobProcessor: any;
+	LowPriorityJobProcessor: any;
+} {
+	jest.resetModules();
+	if (envValue === undefined) {
+		delete process.env.BULL_CONCURRENCY;
+	} else {
+		process.env.BULL_CONCURRENCY = envValue;
+	}
+	// require est intentionnel ici pour contourner le cache de modules ESM
+
+	return require('./job.processor');
+}
+
+describe('Job processors decorator metadata', () => {
+	const ORIGINAL_ENV = process.env.BULL_CONCURRENCY;
+
+	afterAll(() => {
+		if (ORIGINAL_ENV === undefined) {
+			delete process.env.BULL_CONCURRENCY;
+		} else {
+			process.env.BULL_CONCURRENCY = ORIGINAL_ENV;
+		}
+	});
+
+	describe('default concurrency from env (BULL_CONCURRENCY unset -> 5)', () => {
+		const { HighPriorityJobProcessor, MediumPriorityJobProcessor, LowPriorityJobProcessor } =
+			loadProcessorsWithEnv(undefined);
+
+		it.each([
+			['HighPriorityJobProcessor', HighPriorityJobProcessor, 'high-priority'],
+			['MediumPriorityJobProcessor', MediumPriorityJobProcessor, 'medium-priority'],
+			['LowPriorityJobProcessor', LowPriorityJobProcessor, 'low-priority'],
+		])('%s exposes queue name + concurrency 5 + maxStalledCount 5', (_name, ctor, expectedQueue) => {
+			const processorMeta = Reflect.getMetadata(PROCESSOR_METADATA, ctor);
+			const workerMeta = Reflect.getMetadata(WORKER_METADATA, ctor);
+
+			expect(processorMeta).toEqual(expect.objectContaining({ name: expectedQueue }));
+			expect(workerMeta).toEqual(expect.objectContaining({ concurrency: 5, maxStalledCount: 5 }));
+		});
+	});
+
+	describe('concurrency override via BULL_CONCURRENCY env var', () => {
+		it('reads BULL_CONCURRENCY=12 from env', () => {
+			const { HighPriorityJobProcessor } = loadProcessorsWithEnv('12');
+			const workerMeta = Reflect.getMetadata(WORKER_METADATA, HighPriorityJobProcessor);
+			expect(workerMeta?.concurrency).toBe(12);
+		});
+
+		it('clamps invalid (NaN) BULL_CONCURRENCY to 1 minimum', () => {
+			const { HighPriorityJobProcessor } = loadProcessorsWithEnv('not-a-number');
+			const workerMeta = Reflect.getMetadata(WORKER_METADATA, HighPriorityJobProcessor);
+			expect(workerMeta?.concurrency).toBe(1);
+		});
+
+		it('clamps zero/negative BULL_CONCURRENCY to 1 minimum', () => {
+			const { LowPriorityJobProcessor } = loadProcessorsWithEnv('0');
+			const workerMeta = Reflect.getMetadata(WORKER_METADATA, LowPriorityJobProcessor);
+			expect(workerMeta?.concurrency).toBe(1);
+		});
+	});
+
+	describe('maxStalledCount = 5 sur les trois processors (alignement avec attempts)', () => {
+		it('chaque processor a maxStalledCount = 5', () => {
+			const { HighPriorityJobProcessor, MediumPriorityJobProcessor, LowPriorityJobProcessor } =
+				loadProcessorsWithEnv('5');
+
+			for (const ctor of [
+				HighPriorityJobProcessor,
+				MediumPriorityJobProcessor,
+				LowPriorityJobProcessor,
+			]) {
+				const workerMeta = Reflect.getMetadata(WORKER_METADATA, ctor);
+				expect(workerMeta?.maxStalledCount).toBe(5);
+			}
+		});
+	});
+});

--- a/src/modules/queues/processors/job.processor.ts
+++ b/src/modules/queues/processors/job.processor.ts
@@ -4,7 +4,7 @@ import { Job } from 'bullmq';
 import { SchedulerService } from '@/modules/scheduler/services/scheduler.service';
 
 // concurrency env-driven pour scaler sous burst (default 1 sinon, queue grossit unboundedly)
-const PARSED_CONCURRENCY = parseInt(process.env.BULL_CONCURRENCY ?? '5', 10);
+const PARSED_CONCURRENCY = Number.parseInt(process.env.BULL_CONCURRENCY ?? '5', 10);
 const CONCURRENCY = Number.isFinite(PARSED_CONCURRENCY) ? Math.max(1, PARSED_CONCURRENCY) : 1;
 // maxStalledCount aligne avec attempts pour ne pas drop silencieusement les jobs OOM-killed
 const MAX_STALLED_COUNT = 5;

--- a/src/modules/queues/processors/job.processor.ts
+++ b/src/modules/queues/processors/job.processor.ts
@@ -9,7 +9,19 @@ const CONCURRENCY = Number.isFinite(PARSED_CONCURRENCY) ? Math.max(1, PARSED_CON
 // maxStalledCount aligne avec attempts pour ne pas drop silencieusement les jobs OOM-killed
 const MAX_STALLED_COUNT = 5;
 
-@Processor('high-priority', { concurrency: CONCURRENCY, maxStalledCount: MAX_STALLED_COUNT })
+// options worker partagees par les trois processors (concurrency + maxStalledCount)
+const WORKER_OPTS = { concurrency: CONCURRENCY, maxStalledCount: MAX_STALLED_COUNT };
+
+// helper alerting commun : log warn-level pour Sonar/Loki sur job echoue apres tous les retries
+function logFailedEvent(logger: Logger, label: string, job: Job, err: Error): void {
+	logger.warn(`${label} worker failed event`, {
+		bullJobId: job?.id,
+		attemptsMade: job?.attemptsMade,
+		error: err?.message,
+	});
+}
+
+@Processor('high-priority', WORKER_OPTS)
 export class HighPriorityJobProcessor extends WorkerHost {
 	private readonly logger = new Logger(HighPriorityJobProcessor.name);
 
@@ -51,18 +63,13 @@ export class HighPriorityJobProcessor extends WorkerHost {
 		}
 	}
 
-	// listener visible Sonar/Loki si un job echoue apres tous les retries (alerting)
 	@OnWorkerEvent('failed')
 	onFailed(job: Job, err: Error): void {
-		this.logger.warn('High priority worker failed event', {
-			bullJobId: job?.id,
-			attemptsMade: job?.attemptsMade,
-			error: err?.message,
-		});
+		logFailedEvent(this.logger, 'High priority', job, err);
 	}
 }
 
-@Processor('medium-priority', { concurrency: CONCURRENCY, maxStalledCount: MAX_STALLED_COUNT })
+@Processor('medium-priority', WORKER_OPTS)
 export class MediumPriorityJobProcessor extends WorkerHost {
 	private readonly logger = new Logger(MediumPriorityJobProcessor.name);
 
@@ -104,18 +111,13 @@ export class MediumPriorityJobProcessor extends WorkerHost {
 		}
 	}
 
-	// listener visible Sonar/Loki si un job echoue apres tous les retries (alerting)
 	@OnWorkerEvent('failed')
 	onFailed(job: Job, err: Error): void {
-		this.logger.warn('Medium priority worker failed event', {
-			bullJobId: job?.id,
-			attemptsMade: job?.attemptsMade,
-			error: err?.message,
-		});
+		logFailedEvent(this.logger, 'Medium priority', job, err);
 	}
 }
 
-@Processor('low-priority', { concurrency: CONCURRENCY, maxStalledCount: MAX_STALLED_COUNT })
+@Processor('low-priority', WORKER_OPTS)
 export class LowPriorityJobProcessor extends WorkerHost {
 	private readonly logger = new Logger(LowPriorityJobProcessor.name);
 
@@ -157,13 +159,8 @@ export class LowPriorityJobProcessor extends WorkerHost {
 		}
 	}
 
-	// listener visible Sonar/Loki si un job echoue apres tous les retries (alerting)
 	@OnWorkerEvent('failed')
 	onFailed(job: Job, err: Error): void {
-		this.logger.warn('Low priority worker failed event', {
-			bullJobId: job?.id,
-			attemptsMade: job?.attemptsMade,
-			error: err?.message,
-		});
+		logFailedEvent(this.logger, 'Low priority', job, err);
 	}
 }

--- a/src/modules/queues/processors/job.processor.ts
+++ b/src/modules/queues/processors/job.processor.ts
@@ -12,155 +12,74 @@ const MAX_STALLED_COUNT = 5;
 // options worker partagees par les trois processors (concurrency + maxStalledCount)
 const WORKER_OPTS = { concurrency: CONCURRENCY, maxStalledCount: MAX_STALLED_COUNT };
 
-// helper alerting commun : log warn-level pour Sonar/Loki sur job echoue apres tous les retries
-function logFailedEvent(logger: Logger, label: string, job: Job, err: Error): void {
-	logger.warn(`${label} worker failed event`, {
-		bullJobId: job?.id,
-		attemptsMade: job?.attemptsMade,
-		error: err?.message,
-	});
+// base partagee par les processors high/medium/low : meme flow d'execution, seul le label change
+abstract class BaseJobProcessor extends WorkerHost {
+	protected abstract readonly priorityLabel: string;
+	protected abstract readonly logger: Logger;
+
+	constructor(private readonly schedulerService: SchedulerService) {
+		super();
+	}
+
+	async process(job: Job): Promise<any> {
+		// on ne traite que les jobs nommes 'execute-job'
+		if (job.name !== 'execute-job') {
+			return;
+		}
+
+		const { jobId, scheduleId } = job.data;
+
+		this.logger.log(`Processing ${this.priorityLabel} priority job`, {
+			jobId,
+			scheduleId,
+			bullJobId: job.id,
+		});
+
+		try {
+			const result = await this.schedulerService.executeJob(jobId, scheduleId, `bull-${job.id}`);
+
+			this.logger.log(`${this.priorityLabel} priority job completed`, {
+				jobId,
+				executionId: result.id,
+				status: result.status,
+			});
+
+			return result;
+		} catch (error) {
+			this.logger.error(`${this.priorityLabel} priority job failed`, {
+				jobId,
+				scheduleId,
+				error: error.message,
+			});
+			throw error;
+		}
+	}
+
+	// listener visible Sonar/Loki si un job echoue apres tous les retries (alerting)
+	@OnWorkerEvent('failed')
+	onFailed(job: Job, err: Error): void {
+		this.logger.warn(`${this.priorityLabel} priority worker failed event`, {
+			bullJobId: job?.id,
+			attemptsMade: job?.attemptsMade,
+			error: err?.message,
+		});
+	}
 }
 
 @Processor('high-priority', WORKER_OPTS)
-export class HighPriorityJobProcessor extends WorkerHost {
-	private readonly logger = new Logger(HighPriorityJobProcessor.name);
-
-	constructor(private schedulerService: SchedulerService) {
-		super();
-	}
-
-	async process(job: Job): Promise<any> {
-		// Only process 'execute-job' jobs
-		if (job.name !== 'execute-job') {
-			return;
-		}
-
-		const { jobId, scheduleId } = job.data;
-
-		this.logger.log('Processing high priority job', {
-			jobId,
-			scheduleId,
-			bullJobId: job.id,
-		});
-
-		try {
-			const result = await this.schedulerService.executeJob(jobId, scheduleId, `bull-${job.id}`);
-
-			this.logger.log('High priority job completed', {
-				jobId,
-				executionId: result.id,
-				status: result.status,
-			});
-
-			return result;
-		} catch (error) {
-			this.logger.error('High priority job failed', {
-				jobId,
-				scheduleId,
-				error: error.message,
-			});
-			throw error;
-		}
-	}
-
-	@OnWorkerEvent('failed')
-	onFailed(job: Job, err: Error): void {
-		logFailedEvent(this.logger, 'High priority', job, err);
-	}
+export class HighPriorityJobProcessor extends BaseJobProcessor {
+	protected readonly priorityLabel = 'High';
+	protected readonly logger = new Logger(HighPriorityJobProcessor.name);
 }
 
 @Processor('medium-priority', WORKER_OPTS)
-export class MediumPriorityJobProcessor extends WorkerHost {
-	private readonly logger = new Logger(MediumPriorityJobProcessor.name);
-
-	constructor(private schedulerService: SchedulerService) {
-		super();
-	}
-
-	async process(job: Job): Promise<any> {
-		// Only process 'execute-job' jobs
-		if (job.name !== 'execute-job') {
-			return;
-		}
-
-		const { jobId, scheduleId } = job.data;
-
-		this.logger.log('Processing medium priority job', {
-			jobId,
-			scheduleId,
-			bullJobId: job.id,
-		});
-
-		try {
-			const result = await this.schedulerService.executeJob(jobId, scheduleId, `bull-${job.id}`);
-
-			this.logger.log('Medium priority job completed', {
-				jobId,
-				executionId: result.id,
-				status: result.status,
-			});
-
-			return result;
-		} catch (error) {
-			this.logger.error('Medium priority job failed', {
-				jobId,
-				scheduleId,
-				error: error.message,
-			});
-			throw error;
-		}
-	}
-
-	@OnWorkerEvent('failed')
-	onFailed(job: Job, err: Error): void {
-		logFailedEvent(this.logger, 'Medium priority', job, err);
-	}
+export class MediumPriorityJobProcessor extends BaseJobProcessor {
+	protected readonly priorityLabel = 'Medium';
+	protected readonly logger = new Logger(MediumPriorityJobProcessor.name);
 }
 
 @Processor('low-priority', WORKER_OPTS)
-export class LowPriorityJobProcessor extends WorkerHost {
-	private readonly logger = new Logger(LowPriorityJobProcessor.name);
-
-	constructor(private schedulerService: SchedulerService) {
-		super();
-	}
-
-	async process(job: Job): Promise<any> {
-		// Only process 'execute-job' jobs
-		if (job.name !== 'execute-job') {
-			return;
-		}
-
-		const { jobId, scheduleId } = job.data;
-
-		this.logger.log('Processing low priority job', {
-			jobId,
-			scheduleId,
-			bullJobId: job.id,
-		});
-
-		try {
-			const result = await this.schedulerService.executeJob(jobId, scheduleId, `bull-${job.id}`);
-
-			this.logger.log('Low priority job completed', {
-				jobId,
-				executionId: result.id,
-				status: result.status,
-			});
-
-			return result;
-		} catch (error) {
-			this.logger.error('Low priority job failed', {
-				jobId,
-				scheduleId,
-				error: error.message,
-			});
-			throw error;
-		}
-	}
-
-	@OnWorkerEvent('failed')
-	onFailed(job: Job, err: Error): void {
-		logFailedEvent(this.logger, 'Low priority', job, err);
-	}
+export class LowPriorityJobProcessor extends BaseJobProcessor {
+	protected readonly priorityLabel = 'Low';
+	protected readonly logger = new Logger(LowPriorityJobProcessor.name);
 }

--- a/src/modules/queues/processors/job.processor.ts
+++ b/src/modules/queues/processors/job.processor.ts
@@ -1,9 +1,15 @@
-import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { SchedulerService } from '@/modules/scheduler/services/scheduler.service';
 
-@Processor('high-priority')
+// concurrency env-driven pour scaler sous burst (default 1 sinon, queue grossit unboundedly)
+const PARSED_CONCURRENCY = parseInt(process.env.BULL_CONCURRENCY ?? '5', 10);
+const CONCURRENCY = Number.isFinite(PARSED_CONCURRENCY) ? Math.max(1, PARSED_CONCURRENCY) : 1;
+// maxStalledCount aligne avec attempts pour ne pas drop silencieusement les jobs OOM-killed
+const MAX_STALLED_COUNT = 5;
+
+@Processor('high-priority', { concurrency: CONCURRENCY, maxStalledCount: MAX_STALLED_COUNT })
 export class HighPriorityJobProcessor extends WorkerHost {
 	private readonly logger = new Logger(HighPriorityJobProcessor.name);
 
@@ -44,9 +50,19 @@ export class HighPriorityJobProcessor extends WorkerHost {
 			throw error;
 		}
 	}
+
+	// listener visible Sonar/Loki si un job echoue apres tous les retries (alerting)
+	@OnWorkerEvent('failed')
+	onFailed(job: Job, err: Error): void {
+		this.logger.warn('High priority worker failed event', {
+			bullJobId: job?.id,
+			attemptsMade: job?.attemptsMade,
+			error: err?.message,
+		});
+	}
 }
 
-@Processor('medium-priority')
+@Processor('medium-priority', { concurrency: CONCURRENCY, maxStalledCount: MAX_STALLED_COUNT })
 export class MediumPriorityJobProcessor extends WorkerHost {
 	private readonly logger = new Logger(MediumPriorityJobProcessor.name);
 
@@ -87,9 +103,19 @@ export class MediumPriorityJobProcessor extends WorkerHost {
 			throw error;
 		}
 	}
+
+	// listener visible Sonar/Loki si un job echoue apres tous les retries (alerting)
+	@OnWorkerEvent('failed')
+	onFailed(job: Job, err: Error): void {
+		this.logger.warn('Medium priority worker failed event', {
+			bullJobId: job?.id,
+			attemptsMade: job?.attemptsMade,
+			error: err?.message,
+		});
+	}
 }
 
-@Processor('low-priority')
+@Processor('low-priority', { concurrency: CONCURRENCY, maxStalledCount: MAX_STALLED_COUNT })
 export class LowPriorityJobProcessor extends WorkerHost {
 	private readonly logger = new Logger(LowPriorityJobProcessor.name);
 
@@ -129,5 +155,15 @@ export class LowPriorityJobProcessor extends WorkerHost {
 			});
 			throw error;
 		}
+	}
+
+	// listener visible Sonar/Loki si un job echoue apres tous les retries (alerting)
+	@OnWorkerEvent('failed')
+	onFailed(job: Job, err: Error): void {
+		this.logger.warn('Low priority worker failed event', {
+			bullJobId: job?.id,
+			attemptsMade: job?.attemptsMade,
+			error: err?.message,
+		});
 	}
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -29,6 +29,7 @@ jest.mock('@nestjs/bullmq', () => ({
 	getQueueToken: jest.fn((name: string) => `BullQueue_${name}`),
 	InjectQueue: jest.fn(() => jest.fn()),
 	Processor: jest.fn(() => jest.fn()),
+	OnWorkerEvent: jest.fn(() => jest.fn()),
 	WorkerHost: class MockWorkerHost {},
 }));
 


### PR DESCRIPTION
## Summary

Fix two BullMQ misconfigs in `src/modules/queues/processors/job.processor.ts`:

- **HIGH** : `@Processor` decorators had no `concurrency` option, so each worker defaulted to 1. Under burst (mass scheduled messages on the same wall-clock), the queue grew unboundedly while a single worker drained.
- **LOW** : `maxStalledCount` defaulted to 1 while `attempts` was 5 in queue defaults. A job stalling once (worker OOM-killed) was silently dropped before the 5 attempts were exhausted.

### Changes

- `concurrency` env-driven via `BULL_CONCURRENCY` (default 5, clamped >= 1, NaN-safe).
- `maxStalledCount: 5` aligned with `attempts: 5` to use the full retry budget on stalled jobs.
- `@OnWorkerEvent('failed')` handler on each processor: warn-level log surfaces failed-after-all-retries jobs in Sonar/Loki.
- `OnWorkerEvent` added to the global `@nestjs/bullmq` test mock in `test/setup.ts` so other specs that import processors don't crash.

### Files touched

- `src/modules/queues/processors/job.processor.ts`
- `src/modules/queues/processors/job.processor.spec.ts` (new, 7 tests)
- `test/setup.ts`

## Test plan

- [x] Unit tests green (126/126)
- [x] Lint clean
- [x] Typecheck clean

Closes WHISPR-1396