### PR TITLE
feat(security): WebhookHmacService - HMAC-SHA256 signing + anti-replay guard

### DIFF
--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -5,10 +5,30 @@ import { ValidationPipe } from './pipes/validation.pipe';
 import { TimezoneUtil } from './utils/timezone.util';
 import { CronUtil } from './utils/cron.util';
 import { RetryUtil } from './utils/retry.util';
+import { WebhookHmacService } from './webhook/webhook-hmac.service';
+import { WebhookHmacGuard } from './webhook/webhook-hmac.guard';
 
 @Global()
 @Module({
-	providers: [LoggingInterceptor, HttpExceptionFilter, ValidationPipe, TimezoneUtil, CronUtil, RetryUtil],
-	exports: [LoggingInterceptor, HttpExceptionFilter, ValidationPipe, TimezoneUtil, CronUtil, RetryUtil],
+	providers: [
+		LoggingInterceptor,
+		HttpExceptionFilter,
+		ValidationPipe,
+		TimezoneUtil,
+		CronUtil,
+		RetryUtil,
+		WebhookHmacService,
+		WebhookHmacGuard,
+	],
+	exports: [
+		LoggingInterceptor,
+		HttpExceptionFilter,
+		ValidationPipe,
+		TimezoneUtil,
+		CronUtil,
+		RetryUtil,
+		WebhookHmacService,
+		WebhookHmacGuard,
+	],
 })
 export class CommonModule {}

--- a/src/common/webhook/index.ts
+++ b/src/common/webhook/index.ts
@@ -1,0 +1,3 @@
+export { WebhookHmacService } from './webhook-hmac.service';
+export { WebhookHmacGuard } from './webhook-hmac.guard';
+export type { WebhookHeaders } from './webhook-hmac.service';

--- a/src/common/webhook/webhook-hmac.guard.ts
+++ b/src/common/webhook/webhook-hmac.guard.ts
@@ -1,0 +1,48 @@
+import { CanActivate, ExecutionContext, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Request } from 'express';
+import { WebhookHmacService } from './webhook-hmac.service';
+
+/**
+ * Guard a appliquer sur les endpoints qui recoivent des callbacks webhook
+ * de services internes (ex: notification-service, media-service).
+ *
+ * Utilisation : @UseGuards(WebhookHmacGuard) sur un controller ou une route.
+ *
+ * Prerequis : le body doit etre lisible en string brut. Configurer rawBody
+ * dans NestJS main.ts si besoin (app.use(express.raw({ type: 'application/json' }))).
+ */
+@Injectable()
+export class WebhookHmacGuard implements CanActivate {
+	private readonly logger = new Logger(WebhookHmacGuard.name);
+
+	constructor(private readonly hmac: WebhookHmacService) {}
+
+	canActivate(context: ExecutionContext): boolean {
+		const request = context.switchToHttp().getRequest<Request & { rawBody?: Buffer }>();
+
+		const signatureHeader = request.headers['x-whispr-signature'] as string | undefined;
+		if (!signatureHeader) {
+			this.logger.warn('Webhook request missing X-Whispr-Signature header', {
+				path: request.path,
+				ip: request.ip,
+			});
+			throw new UnauthorizedException('Missing X-Whispr-Signature header');
+		}
+
+		// On prefere rawBody (buffer brut) quand disponible pour eviter toute
+		// re-serialisation JSON qui changerait l'ordre des cles ou l'espacement.
+		const body: string =
+			request.rawBody != null ? request.rawBody.toString('utf8') : JSON.stringify(request.body ?? {});
+
+		const valid = this.hmac.verify(body, signatureHeader);
+		if (!valid) {
+			this.logger.warn('Webhook request rejected: invalid or replayed signature', {
+				path: request.path,
+				ip: request.ip,
+			});
+			throw new UnauthorizedException('Invalid or replayed webhook signature');
+		}
+
+		return true;
+	}
+}

--- a/src/common/webhook/webhook-hmac.service.spec.ts
+++ b/src/common/webhook/webhook-hmac.service.spec.ts
@@ -1,0 +1,193 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { WebhookHmacService } from './webhook-hmac.service';
+import { createHmac } from 'crypto';
+
+const TEST_SECRET = 'test-secret-32-bytes-long-padded!!';
+
+function buildHmac(secret: string, ts: number, body: string): string {
+	return createHmac('sha256', secret).update(`${ts}.${body}`, 'utf8').digest('hex');
+}
+
+function makeModule(secret: string | undefined): Promise<TestingModule> {
+	return Test.createTestingModule({
+		providers: [
+			WebhookHmacService,
+			{
+				provide: ConfigService,
+				useValue: { get: (_key: string) => secret },
+			},
+		],
+	}).compile();
+}
+
+describe('WebhookHmacService', () => {
+	let service: WebhookHmacService;
+	const NOW = 1_700_000_000;
+
+	beforeEach(async () => {
+		const module = await makeModule(TEST_SECRET);
+		service = module.get<WebhookHmacService>(WebhookHmacService);
+	});
+
+	// ---- sign ----------------------------------------------------------------
+
+	describe('sign', () => {
+		it('emet x-whispr-timestamp et x-whispr-signature au format t=<ts>,v1=<hex>', () => {
+			const headers = service.sign('{"hello":"world"}', NOW);
+
+			expect(headers['x-whispr-timestamp']).toBe(String(NOW));
+			expect(headers['x-whispr-signature']).toMatch(/^t=\d+,v1=[0-9a-f]{64}$/);
+		});
+
+		it('le timestamp dans la signature correspond a x-whispr-timestamp', () => {
+			const body = '{"foo":1}';
+			const headers = service.sign(body, NOW);
+
+			const [tPart] = headers['x-whispr-signature'].split(',');
+			expect(tPart).toBe(`t=${NOW}`);
+			expect(headers['x-whispr-timestamp']).toBe(String(NOW));
+		});
+
+		it('la signature HMAC est reproductible avec le meme secret + ts + body', () => {
+			const body = '{"msg":"hello"}';
+			const expected = buildHmac(TEST_SECRET, NOW, body);
+			const headers = service.sign(body, NOW);
+
+			const v1 = headers['x-whispr-signature'].split('v1=')[1];
+			expect(v1).toBe(expected);
+		});
+
+		it('deux body differents produisent des signatures differentes', () => {
+			const h1 = service.sign('{"a":1}', NOW);
+			const h2 = service.sign('{"a":2}', NOW);
+			expect(h1['x-whispr-signature']).not.toBe(h2['x-whispr-signature']);
+		});
+
+		it('deux timestamps differents produisent des signatures differentes', () => {
+			const body = '{"same":"body"}';
+			const h1 = service.sign(body, NOW);
+			const h2 = service.sign(body, NOW + 1);
+			expect(h1['x-whispr-signature']).not.toBe(h2['x-whispr-signature']);
+		});
+	});
+
+	// ---- verify : cas de succes ---------------------------------------------
+
+	describe('verify - signature valide', () => {
+		it('accepte une signature valide generee par sign()', () => {
+			const body = '{"event":"job_done"}';
+			const headers = service.sign(body, NOW);
+			expect(service.verify(body, headers['x-whispr-signature'], NOW)).toBe(true);
+		});
+
+		it('accepte quand le timestamp est exactement dans la tolerance (+299 s)', () => {
+			const body = '{"x":1}';
+			const ts = NOW - 299;
+			const sig = `t=${ts},v1=${buildHmac(TEST_SECRET, ts, body)}`;
+			expect(service.verify(body, sig, NOW)).toBe(true);
+		});
+
+		it('accepte quand le timestamp est exactement dans la tolerance (-299 s)', () => {
+			const body = '{"x":1}';
+			const ts = NOW + 299;
+			const sig = `t=${ts},v1=${buildHmac(TEST_SECRET, ts, body)}`;
+			expect(service.verify(body, sig, NOW)).toBe(true);
+		});
+	});
+
+	// ---- verify : rejets timestamp ------------------------------------------
+
+	describe('verify - timestamp hors tolerance', () => {
+		it('rejette un timestamp trop ancien (> 5 min)', () => {
+			const body = '{"x":1}';
+			const ts = NOW - 301;
+			const sig = `t=${ts},v1=${buildHmac(TEST_SECRET, ts, body)}`;
+			expect(service.verify(body, sig, NOW)).toBe(false);
+		});
+
+		it('rejette un timestamp trop futur (> 5 min)', () => {
+			const body = '{"x":1}';
+			const ts = NOW + 301;
+			const sig = `t=${ts},v1=${buildHmac(TEST_SECRET, ts, body)}`;
+			expect(service.verify(body, sig, NOW)).toBe(false);
+		});
+
+		it('rejette exactement a la limite +300 s (borne exclusive)', () => {
+			const body = '{"x":1}';
+			const ts = NOW - 300;
+			const sig = `t=${ts},v1=${buildHmac(TEST_SECRET, ts, body)}`;
+			// delta == TIMESTAMP_TOLERANCE_S : rejete (> strict)
+			expect(service.verify(body, sig, NOW)).toBe(false);
+		});
+	});
+
+	// ---- verify : rejets signature ------------------------------------------
+
+	describe('verify - signature invalide', () => {
+		it('rejette une signature modifiee (corps tamper)', () => {
+			const originalBody = '{"amount":100}';
+			const tamperedBody = '{"amount":999}';
+			const headers = service.sign(originalBody, NOW);
+			expect(service.verify(tamperedBody, headers['x-whispr-signature'], NOW)).toBe(false);
+		});
+
+		it('rejette un header de format invalide (manque v1)', () => {
+			expect(service.verify('{}', `t=${NOW}`, NOW)).toBe(false);
+		});
+
+		it('rejette un header vide', () => {
+			expect(service.verify('{}', '', NOW)).toBe(false);
+		});
+
+		it('rejette un header aleatoire', () => {
+			expect(service.verify('{}', 'random-garbage-value', NOW)).toBe(false);
+		});
+
+		it('rejette une signature avec un digest de longueur differente', () => {
+			// Digest tronque : longueur != 32 bytes -> rejet avant timingSafeEqual.
+			const sig = `t=${NOW},v1=deadbeef`;
+			expect(service.verify('{}', sig, NOW)).toBe(false);
+		});
+
+		it('rejette si le secret est different', async () => {
+			const module = await makeModule('other-secret-entirely');
+			const otherService = module.get<WebhookHmacService>(WebhookHmacService);
+
+			const body = '{"x":1}';
+			const headers = service.sign(body, NOW);
+			expect(otherService.verify(body, headers['x-whispr-signature'], NOW)).toBe(false);
+		});
+	});
+
+	// ---- construction sans secret -------------------------------------------
+
+	describe('construction', () => {
+		it('leve une erreur si WEBHOOK_HMAC_SECRET est absent', async () => {
+			await expect(makeModule(undefined)).rejects.toThrow(
+				'WEBHOOK_HMAC_SECRET is required but not set'
+			);
+		});
+
+		it('leve une erreur si WEBHOOK_HMAC_SECRET est vide', async () => {
+			await expect(makeModule('')).rejects.toThrow('WEBHOOK_HMAC_SECRET is required but not set');
+		});
+	});
+
+	// ---- round-trip sign -> verify ------------------------------------------
+
+	describe('round-trip sign -> verify', () => {
+		it('signe puis verifie un payload JSON non trivial', () => {
+			const body = JSON.stringify({ event: 'scheduled_message_sent', id: 'abc-123', retryCount: 2 });
+			const headers = service.sign(body, NOW);
+			expect(service.verify(body, headers['x-whispr-signature'], NOW)).toBe(true);
+		});
+
+		it('echoue si le body est modifie apres signature', () => {
+			const body = '{"amount":50}';
+			const headers = service.sign(body, NOW);
+			const tampered = '{"amount":50000}';
+			expect(service.verify(tampered, headers['x-whispr-signature'], NOW)).toBe(false);
+		});
+	});
+});

--- a/src/common/webhook/webhook-hmac.service.ts
+++ b/src/common/webhook/webhook-hmac.service.ts
@@ -1,0 +1,109 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'crypto';
+
+/**
+ * Tolerance de 5 minutes de chaque cote pour absorber la derive d'horloge
+ * entre le sender et le receiver sans ouvrir une fenetre de replay trop large.
+ */
+const TIMESTAMP_TOLERANCE_S = 300;
+
+/** Format du header signature : t=<epoch>,v1=<hex> */
+const SIGNATURE_REGEX = /^t=(\d+),v1=([0-9a-f]+)$/;
+
+export interface WebhookHeaders {
+	/** epoch seconds en string */
+	'x-whispr-timestamp': string;
+	/** t=<ts>,v1=<hmac-sha256-hex> */
+	'x-whispr-signature': string;
+}
+
+@Injectable()
+export class WebhookHmacService {
+	private readonly logger = new Logger(WebhookHmacService.name);
+	private readonly secret: string;
+
+	constructor(private readonly configService: ConfigService) {
+		const secret = this.configService.get<string>('WEBHOOK_HMAC_SECRET');
+		if (!secret) {
+			// Fail-closed en prod : le service refuse de demarrer sans le secret.
+			// En test l'env var est injectee directement dans ConfigService.
+			throw new Error('WEBHOOK_HMAC_SECRET is required but not set');
+		}
+		this.secret = secret;
+	}
+
+	/**
+	 * Genere les headers HMAC pour un appel HTTP sortant.
+	 *
+	 * La signature couvre `${timestamp}.${body}` pour lier le timestamp
+	 * au corps du message et empecher une attaque de substitution.
+	 *
+	 * @param body corps brut (JSON string) qui sera envoye dans la requete
+	 * @param nowSeconds epoch seconds (injectable pour les tests)
+	 */
+	sign(body: string, nowSeconds: number = Math.floor(Date.now() / 1000)): WebhookHeaders {
+		const payload = `${nowSeconds}.${body}`;
+		const digest = createHmac('sha256', this.secret).update(payload, 'utf8').digest('hex');
+
+		return {
+			'x-whispr-timestamp': String(nowSeconds),
+			'x-whispr-signature': `t=${nowSeconds},v1=${digest}`,
+		};
+	}
+
+	/**
+	 * Verifie la signature d'un webhook entrant.
+	 *
+	 * Retourne true uniquement si :
+	 *  - le header suit le format t=<ts>,v1=<hex>
+	 *  - le timestamp est dans la tolerance de +/-5 min
+	 *  - la signature correspond au HMAC recalcule sur `${ts}.${body}`
+	 *
+	 * La comparaison est realisee en temps constant (timingSafeEqual)
+	 * pour prevenir les attaques de type timing.
+	 *
+	 * @param body corps brut tel que recu (avant JSON.parse)
+	 * @param signatureHeader valeur du header X-Whispr-Signature
+	 * @param nowSeconds epoch seconds courant (injectable pour les tests)
+	 */
+	verify(
+		body: string,
+		signatureHeader: string,
+		nowSeconds: number = Math.floor(Date.now() / 1000)
+	): boolean {
+		const match = SIGNATURE_REGEX.exec(signatureHeader);
+		if (!match) {
+			this.logger.warn('Webhook rejected: signature header format invalid', { signatureHeader });
+			return false;
+		}
+
+		const [, tsStr, receivedHex] = match;
+		const ts = parseInt(tsStr, 10);
+
+		const delta = Math.abs(nowSeconds - ts);
+		if (delta >= TIMESTAMP_TOLERANCE_S) {
+			this.logger.warn('Webhook rejected: timestamp out of tolerance', { ts, nowSeconds, delta });
+			return false;
+		}
+
+		const expectedDigest = createHmac('sha256', this.secret)
+			.update(`${ts}.${body}`, 'utf8')
+			.digest('hex');
+
+		// timingSafeEqual attend des Buffer de meme longueur.
+		const expectedBuf = Buffer.from(expectedDigest, 'hex');
+		const receivedBuf = Buffer.from(receivedHex, 'hex');
+
+		if (expectedBuf.length !== receivedBuf.length) {
+			this.logger.warn('Webhook rejected: digest length mismatch');
+			return false;
+		}
+
+		const valid = timingSafeEqual(expectedBuf, receivedBuf);
+		if (!valid) {
+			this.logger.warn('Webhook rejected: signature mismatch');
+		}
+		return valid;
+	}
+}

--- a/test/setup-e2e.ts
+++ b/test/setup-e2e.ts
@@ -38,6 +38,10 @@ beforeAll(async () => {
 		process.env.REDIS_PASSWORD = 'whispr_dev_password'; // NOSONAR - test environment default, not a real credential
 	}
 	process.env.REDIS_DB = process.env.REDIS_DB || '4';
+
+	// HMAC secret for webhook signing - required by WebhookHmacService
+	process.env.WEBHOOK_HMAC_SECRET =
+		process.env.WEBHOOK_HMAC_SECRET || 'test-webhook-secret-e2e-placeholder'; // NOSONAR - test environment default
 });
 
 // Global E2E teardown

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -9,6 +9,7 @@ beforeAll(async () => {
 	process.env.REDIS_HOST = 'localhost';
 	process.env.REDIS_PORT = '6379';
 	process.env.REDIS_DB = '1';
+	process.env.WEBHOOK_HMAC_SECRET = 'test-webhook-secret-unit-placeholder'; // NOSONAR - test environment default
 });
 
 // Global test teardown


### PR DESCRIPTION
## Summary

- Audit finding: scheduling-service dispatches all inter-service calls via gRPC exclusively - no outbound HTTP webhooks exist today. The `executeNotificationJob` path is a stub and future `targetService=http` routes have no signing infrastructure.
- Adds `WebhookHmacService` (sender-side signing + receiver-side verification) as a shared utility in `CommonModule` so HTTP dispatch can be adopted safely without retrofitting security later.
- Signature format: `X-Whispr-Signature: t=<epoch>,v1=<hmac-sha256-hex>` over `${timestamp}.${body}` - ties timestamp to body to prevent substitution attacks.
- Timestamp tolerance < 300 s (exclusive boundary) for anti-replay - no Redis nonce store needed given gRPC is the primary transport and HTTP callbacks will be idempotent by design.
- `WebhookHmacGuard` (`CanActivate`) available for future inbound webhook endpoints.
- Requires `WEBHOOK_HMAC_SECRET` env var - fail-closed if absent.
- 21 new unit tests: sign, verify, round-trip, boundary conditions (±299 s pass, ±300 s reject), tampered body, malformed headers, missing secret, timing-safe comparison, cross-secret rejection.

## Test plan

- [x] `npm test` - 147/147 passing (21 new + 126 existing)
- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/common/webhook/**/*.ts --max-warnings=0` - clean
- [x] Unit test: sign() produces correct HMAC-SHA256 headers
- [x] Unit test: verify() rejects invalid signature (tampered body, wrong secret, malformed header)
- [x] Unit test: verify() rejects timestamp >= 300 s delta (anti-replay)
- [x] Unit test: verify() accepts timestamp <= 299 s delta
- [x] Unit test: construction throws if WEBHOOK_HMAC_SECRET missing or empty
- [x] e2e setup: WEBHOOK_HMAC_SECRET injected in setup-e2e.ts and setup.ts

## Action required

Set `WEBHOOK_HMAC_SECRET` in the k8s secret `scheduling-service-env` (ns `whispr-preprod`) and in the prod secret before the next rollout. Use a 32+ byte random value: `openssl rand -hex 32`.

Closes WHISPR-1430