### PR TITLE
ci(docker): tolerate sigstore rekor timeouts on attestation steps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -133,9 +133,14 @@ jobs:
             exit 1
           fi
 
+      # Sigstore Rekor tlog uploads occasionally time out and are not
+      # required for the image to be deployable. Treat both attestation
+      # steps as best-effort so transient sigstore.dev outages do not
+      # block the build pipeline.
       - name: Attest SBOM to image
         if: inputs.should_deploy == true
         uses: actions/attest-sbom@21f269c03431211cf2de4a1b5d90001746539dc9 # v1
+        continue-on-error: true
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -145,6 +150,7 @@ jobs:
       - name: Generate provenance attestation
         if: inputs.should_deploy == true
         uses: actions/attest-build-provenance@92c65d2898f1f53cfdc910b962cecff86e7f8fcc # v1
+        continue-on-error: true
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
## Summary
- Push CI on deploy/preprod (run 25638820942, merge commit 7a26c08c) failed on the `actions/attest-build-provenance` step with `FetchError: network timeout at https://rekor.sigstore.dev/...`.
- The docker image was built, pushed, scanned with Trivy, and the SBOM attest already succeeded. The provenance attest tlog upload was the only failing step, but it gated the whole pipeline.
- Without this fix, image `sha-7a26c08` is never promoted and ArgoCD keeps rolling out the old `8d83a20`, so the privilege-escalation fix from PR #83 (`InternalApiGuard` on `/api/v1/jobs`) is not live.
- Mark `attest-sbom` and `attest-build-provenance` as `continue-on-error: true` so transient sigstore.dev outages stop blocking deployment.

## Test plan
- [x] `git diff` review: only `.github/workflows/docker.yml` changed
- [ ] CI green on this PR
- [ ] After merge to deploy/preprod, image `sha-7a26c08` (or rebuild SHA) actually pushed to ghcr.io
- [ ] ArgoCD rolls out the new image on whispr-preprod

Closes WHISPR-1448