### PR TITLE
fix(typeorm): register all migrations so DB_MIGRATIONS_RUN applies the full chain

### DIFF
--- a/src/modules/app/typeorm.ts
+++ b/src/modules/app/typeorm.ts
@@ -11,6 +11,10 @@ import { ScheduledMessage } from '../scheduled-messages/entities/scheduled-messa
 import { DataSourceOptions } from 'typeorm';
 import { InitialSchema1743070800000 } from './migrations/1743070800000-InitialSchema';
 import { AddScheduledMessages1743070800001 } from './migrations/1743070800001-AddScheduledMessages';
+import { AddProcessingStatusScheduledMessages1746790000000 } from './migrations/1746790000000-AddProcessingStatusScheduledMessages';
+import { AlterScheduledMessagesTimestamptz1746830000000 } from './migrations/1746830000000-AlterScheduledMessagesTimestamptz';
+import { JobsCategoryFkSetNull1746900000000 } from './migrations/1746900000000-JobsCategoryFkSetNull';
+import { AddRetryCountScheduledMessages1746950000000 } from './migrations/1746950000000-AddRetryCountScheduledMessages';
 
 // Register new TypeORM entities here
 const ENTITIES = [
@@ -71,8 +75,16 @@ function getDataSourceOptions(configService: ConfigService): DataSourceOptions {
 		// Indicates if logging is enabled or not. If set to true then query and error logging will be enabled.
 		logging: configService.get('DB_LOGGING', 'false') === 'true',
 		// Migrations to be loaded and used for this data source
-		// Explicit path (no glob) avoids DirectoryExportedClassesLoader infinite recursion (stack overflow)
-		migrations: [InitialSchema1743070800000, AddScheduledMessages1743070800001],
+		// Explicit class list (no glob) avoids DirectoryExportedClassesLoader infinite recursion (stack overflow)
+		// Add any new migration class here so it runs at boot when DB_MIGRATIONS_RUN=true
+		migrations: [
+			InitialSchema1743070800000,
+			AddScheduledMessages1743070800001,
+			AddProcessingStatusScheduledMessages1746790000000,
+			AlterScheduledMessagesTimestamptz1746830000000,
+			JobsCategoryFkSetNull1746900000000,
+			AddRetryCountScheduledMessages1746950000000,
+		],
 		// Indicates if migrations should be auto-run on every application launch.
 		migrationsRun: configService.get('DB_MIGRATIONS_RUN', 'false') === 'true',
 		// Indicates if database schema should be auto created on every application launch.


### PR DESCRIPTION
## Summary
- The migrations list in `src/modules/app/typeorm.ts` only contained the first two classes, so the 4 follow-up migrations (processing status enum, timestamptz, jobs FK SET NULL, retry_count) were never run at boot even with `DB_MIGRATIONS_RUN=true`.
- Production scheduling-service is currently broken because the `scheduled_messages` table is missing (the migration was listed but the chain never extended).
- Append every new migration class to the explicit list. Glob pattern is still avoided due to the prior `DirectoryExportedClassesLoader` stack overflow regression.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` green via pre-push hook (full Jest + e2e suite)
- [ ] Confirm on preprod boot that all 6 migrations are applied (`SELECT name FROM migrations`)

Closes WHISPR-1457